### PR TITLE
fix(prompt): language directive — principle-based with code-switching / translation support

### DIFF
--- a/utils/src/prompt.spec.ts
+++ b/utils/src/prompt.spec.ts
@@ -101,7 +101,7 @@ describe('Prompt', () => {
         <section name="conversation_history" purpose="用于参考">对话历史</section>
         <section name="empty_context"><empty /></section>
       </context>
-      <language priority="critical">Your language is "中文". Always respond in this language unless the user asks you to use a different one.</language>
+      <language priority="critical">Preferred response language: "中文". Use this by default. Match the user's current message language if they actively switch (code-switching), and honor explicit requests to use another language (e.g., "Please speak Spanish"). For translation queries ("how do you say X in Y"), answer in the preferred language and embed the translation.</language>
       ------
       When responding, always consider all context items, and always prioritize higher-priority items first: critical > high > medium > low.
       Now:2024-01-15 Monday 10:30 in the morning (UTC)
@@ -174,7 +174,7 @@ describe('PromptBuilder', () => {
       <context>
         <section name="section" priority="critical">内容</section>
       </context>
-      <language priority="critical">Your language is "zh-Hans". Always respond in this language unless the user asks you to use a different one.</language>
+      <language priority="critical">Preferred response language: "zh-Hans". Use this by default. Match the user's current message language if they actively switch (code-switching), and honor explicit requests to use another language (e.g., "Please speak Spanish"). For translation queries ("how do you say X in Y"), answer in the preferred language and embed the translation.</language>
       ------
       When responding, always consider all context items, and always prioritize higher-priority items first: critical > high > medium > low.
       Now:2024-01-15 Monday 10:30 in the morning (UTC)

--- a/utils/src/prompt.xml.ts
+++ b/utils/src/prompt.xml.ts
@@ -145,7 +145,7 @@ export class Prompt {
     const audiencePart = this.data.audience ? `<audience>${this.data.audience}</audience>` : '';
     const outputPart = this.data.output ? `<output priority="high">${this.data.output}</output>` : '';
     const languagePart = this.data.language
-      ? `<language priority="critical">Your language is "${this.data.language}". Always respond in this language unless the user asks you to use a different one.</language>`
+      ? `<language priority="critical">Preferred response language: "${this.data.language}". Use this by default. Match the user's current message language if they actively switch (code-switching), and honor explicit requests to use another language (e.g., "Please speak Spanish"). For translation queries ("how do you say X in Y"), answer in the preferred language and embed the translation.</language>`
       : '';
 
     const instructionsPart = this.data.instructions.length


### PR DESCRIPTION
## Summary

Refine the `<language>` directive wording from "Always respond unless user asks" to principle-based, covering more edge cases robustly.

## Background

The previous wording (`Always respond in this language unless the user asks you to use a different one.`) was:
- Too rigid ("Always" + `critical` priority overweights the main directive)
- Missing nuance for code-switching scenarios
- Missing nuance for translation queries (e.g., "how do you say X in Japanese?" — user asking about Japanese in English shouldn't trigger Japanese response)

## Change

```diff
- <language priority="critical">Your language is "X". Always respond in this language unless the user asks you to use a different one.</language>
+ <language priority="critical">Preferred response language: "X". Use this by default. Match the user's current message language if they actively switch (code-switching), and honor explicit requests to use another language (e.g., "Please speak Spanish"). For translation queries ("how do you say X in Y"), answer in the preferred language and embed the translation.</language>
```

Same `critical` priority, same semantic intent, but explicit principles for:
1. **Default**: use preferred language
2. **Code-switching**: match user if they actively switch
3. **Explicit requests**: honor "Please speak X" / "Can you use X"
4. **Translation queries**: answer in preferred, embed translation

## Verification (via downstream CLI in unee-ai-persona)

Tested live with `openrouter:gemini-3-flash-preview` using persona's `prompt:render-test` CLI:

| Scenario | Preferred | User Message | AI Response | Result |
|---|---|---|---|---|
| Language learning switch | English | "Can you please speak to me in Spanish from now on? I'm learning." | "¡Claro que sí! Qué buena idea, me encanta acompañarte en esto..." | ✅ Switched to Spanish |
| Translation query | English | "How do you say good morning in Japanese?" | "In Japanese, you say 'Ohayou gozaimasu'. If you're talking to friends..." | ✅ English response with Japanese translation embedded |
| Baseline | Spanish | "Hola, ¿cómo estás hoy?" | "¡Hola! Qué gusto saludarte. Pues estoy muy bien..." | ✅ Spanish response |

All three scenarios behave as expected.

## Test plan
- [x] `bun test utils/src/prompt.spec.ts` passes (7 tests, updated assertions to match new wording)
- [x] `bun test` full suite passes (334 tests)
- [x] Downstream CLI live LLM test (3 scenarios all pass)
- [ ] Downstream consumer (unee-ai-persona) PR to update submodule reference