### PR TITLE
feat: gRPC GOAWAY drain in graceful shutdown (Phase 2.6)

### DIFF
--- a/env/src/configure.ts
+++ b/env/src/configure.ts
@@ -288,8 +288,7 @@ export class AbstractEnvironmentVariables implements HostSetVariables {
    * - 超过此时间后强制关闭，避免无限等待
    * - 应小于 K8s terminationGracePeriodSeconds 减去 preStop 延迟
    *
-   * 计算公式：IN_FLIGHT_TIMEOUT_MS < terminationGracePeriodSeconds - preStop sleep
-   * 当前配置：terminationGracePeriodSeconds=90s, preStop=10s → IN_FLIGHT_TIMEOUT_MS < 80s
+   * 计算公式：IN_FLIGHT_TIMEOUT_MS < terminationGracePeriodSeconds - preStop - DRAIN_DELAY_MS
    * 默认：60s（支持最长 1 分钟的请求如 chat API）
    */
   @Type(() => Number) @IsNumber() @IsOptional() IN_FLIGHT_TIMEOUT_MS: number = 60_000;
@@ -307,7 +306,16 @@ export class AbstractEnvironmentVariables implements HostSetVariables {
    *
    * 默认 10s，覆盖 K8s readiness probe 周期(3s) + endpoint 传播延迟
    */
-  @Type(() => Number) @IsNumber() @IsOptional() DRAIN_DELAY_MS: number = 10_000;
+  @Type(() => Number) @IsNumber() @IsOptional() DRAIN_DELAY_MS: number = 15_000;
+
+  /**
+   * gRPC drain grace period（毫秒）
+   *
+   * Phase 2.6 调用 grpc.Server.drain(port, graceTimeMs)，发送 GOAWAY 帧。
+   * 已有连接在 graceTimeMs 内完成请求后被关闭，新连接立即被拒绝。
+   * fire-and-forget：drain 的 grace 计时器和 Phase 3 的 in-flight timeout 并行跑。
+   */
+  @Type(() => Number) @IsNumber() @IsOptional() GRPC_DRAIN_MS: number = 60_000;
 
   get environment() {
     const env = this.ENV ?? this.DOPPLER_ENVIRONMENT ?? 'dev';

--- a/nest/src/boot/bootstrap.ts
+++ b/nest/src/boot/bootstrap.ts
@@ -366,7 +366,7 @@ export async function bootstrap(
       },
       { inheritAppConfig: true },
     );
-    setGrpcMicroserviceRef(grpcMs);
+    setGrpcMicroserviceRef(grpcMs, grpcPort);
 
     await app.startAllMicroservices();
     bootstrapLogger.info`[gRPC] Microservice started on port ${grpcPort}${enableReflection ? ' (reflection enabled)' : ''}`;

--- a/nest/src/boot/lifecycle.ts
+++ b/nest/src/boot/lifecycle.ts
@@ -1,5 +1,5 @@
 import { SysEnv } from '@app/env';
-import { grpcMicroserviceRef, shutdownState } from '@app/nest/boot/shutdown-state';
+import { grpcMicroserviceRef, grpcPort, shutdownState } from '@app/nest/boot/shutdown-state';
 import { ConnectionManagerService } from '@app/nest/connection/connection-manager.service';
 import { getAppLogger } from '@app/utils/app-logger';
 import { getErrorMessage } from '@app/utils/error';
@@ -167,6 +167,25 @@ export const runApp = <App extends INestApplication>(app: App) => {
       logger.info`(${os.hostname}) [${signal}] Phase 2.5: client notifications complete at +${elapsed()}`;
     } catch (e) {
       logger.warning`(${os.hostname}) [${signal}] Phase 2.5: failed: ${getErrorMessage(e)}`;
+    }
+
+    // --- Phase 2.6: gRPC GOAWAY drain (fire-and-forget) ---
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- NestJS internals not typed
+      const msForDrain = grpcMicroserviceRef as any;
+      const grpcServerForDrain = msForDrain?.serverInstance?.grpcClient as
+        | { drain?: (port: string, graceTimeMs: number) => void }
+        | undefined;
+      if (grpcServerForDrain?.drain && grpcPort !== undefined) {
+        const grpcUrl = `0.0.0.0:${grpcPort}`;
+        const GRPC_DRAIN_MS = SysEnv.GRPC_DRAIN_MS;
+        logger.info`(${os.hostname}) [${signal}] Phase 2.6: gRPC drain ${grpcUrl} graceTimeMs=${GRPC_DRAIN_MS} (fire-and-forget) at +${elapsed()}`;
+        grpcServerForDrain.drain(grpcUrl, GRPC_DRAIN_MS);
+      } else {
+        logger.info`(${os.hostname}) [${signal}] Phase 2.6: skip (no grpc server or port)`;
+      }
+    } catch (e) {
+      logger.warning`(${os.hostname}) [${signal}] Phase 2.6: failed: ${getErrorMessage(e)}`;
     }
 
     // --- Phase 3: 停止接收 + 等待 in-flight ---

--- a/nest/src/boot/shutdown-state.ts
+++ b/nest/src/boot/shutdown-state.ts
@@ -13,7 +13,9 @@ export const shutdownState = { value: false };
  * 这些不在公开接口上。lifecycle.ts 中通过运行时检查安全访问。
  */
 export let grpcMicroserviceRef: unknown = undefined;
+export let grpcPort: number | undefined = undefined;
 
-export function setGrpcMicroserviceRef(ref: unknown) {
+export function setGrpcMicroserviceRef(ref: unknown, port: number) {
   grpcMicroserviceRef = ref;
+  grpcPort = port;
 }


### PR DESCRIPTION
## Summary

Add `Server.drain()` call during shutdown to send GOAWAY frames to connected gRPC clients before `tryShutdown`.

**4 files**:
- `shutdown-state.ts`: export `grpcPort`, `setGrpcMicroserviceRef(ref, port)`
- `bootstrap.ts`: pass `grpcPort` to setter
- `lifecycle.ts`: Phase 2.6 fire-and-forget `drain(port, GRPC_DRAIN_MS)`
- `configure.ts`: `DRAIN_DELAY_MS` 10→15s, new `GRPC_DRAIN_MS`=60s

**Shutdown sequence**:
```
Phase 1: shutdownState=true (health → NOT_SERVING)
Phase 2: DRAIN_DELAY 15s (wait for LB propagation)
Phase 2.5: close SSE/WS
Phase 2.6: gRPC drain GOAWAY (fire-and-forget, 60s grace) ← NEW
Phase 3: HTTP close + gRPC tryShutdown (60s in-flight timeout)
Phase 4: app.close()
Phase 5: exit
```

**Parameter set**: preStop=15s, DRAIN_DELAY=15s, GRPC_DRAIN=60s, IN_FLIGHT_TIMEOUT=60s, TGPS=120s

## Test plan
- [x] typecheck + lint + 360 tests pass
- [ ] Deploy to staging → rolling update → verify GOAWAY in Loki logs
- [ ] Verify no gRPC CANCELLED errors during deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)