### PR TITLE
Extend Oops status contract

### DIFF
--- a/nest/src/exceptions/grpc-exception.filter.spec.ts
+++ b/nest/src/exceptions/grpc-exception.filter.spec.ts
@@ -231,6 +231,36 @@ describe('GrpcExceptionFilter', () => {
       }
     });
 
+    it('Oops.Block request-boundary statuses should map to specific gRPC statuses', async () => {
+      const cases = [
+        { httpStatus: 408 as const, grpcStatus: status.DEADLINE_EXCEEDED },
+        { httpStatus: 413 as const, grpcStatus: status.RESOURCE_EXHAUSTED },
+        { httpStatus: 415 as const, grpcStatus: status.INVALID_ARGUMENT },
+      ];
+
+      for (const { httpStatus, grpcStatus } of cases) {
+        const { host } = mockGrpcHost();
+        const exception = new Oops.Block({
+          httpStatus,
+          errorCode: '0x0101',
+          oopsCode: 'ST01',
+          userMessage: 'stream request blocked',
+        });
+
+        const result$ = filter.catch(exception, host);
+
+        try {
+          await firstValueFrom(result$);
+          expect.unreachable('expected Oops.Block to be thrown as gRPC error');
+        } catch (error: unknown) {
+          const grpcError = error as { code: number; details: string };
+          expect(grpcError.code).toBe(grpcStatus);
+          const parsed = JSON.parse(grpcError.details) as { httpStatus: number };
+          expect(parsed.httpStatus).toBe(httpStatus);
+        }
+      }
+    });
+
     it('Oops.Panic (500) should throw INTERNAL', async () => {
       const { host } = mockGrpcHost();
       const exception = Oops.Panic.Database('query failed');

--- a/nest/src/exceptions/grpc-exception.filter.spec.ts
+++ b/nest/src/exceptions/grpc-exception.filter.spec.ts
@@ -275,5 +275,31 @@ describe('GrpcExceptionFilter', () => {
         expect(grpcError.code).toBe(status.INTERNAL);
       }
     });
+
+    it('Oops.Panic upstream failure statuses should throw UNAVAILABLE', async () => {
+      const cases = [502, 503] as const;
+
+      for (const httpStatus of cases) {
+        const { host } = mockGrpcHost();
+        const exception = new Oops.Panic({
+          httpStatus,
+          errorCode: '0x0303',
+          userMessage: 'upstream unavailable',
+          internalDetails: 'dependency outage',
+        });
+
+        const result$ = filter.catch(exception, host);
+
+        try {
+          await firstValueFrom(result$);
+          expect.unreachable('expected Oops.Panic to be thrown as gRPC error');
+        } catch (error: unknown) {
+          const grpcError = error as { code: number; details: string };
+          expect(grpcError.code).toBe(status.UNAVAILABLE);
+          const parsed = JSON.parse(grpcError.details) as { httpStatus: number };
+          expect(parsed.httpStatus).toBe(httpStatus);
+        }
+      }
+    });
   });
 });

--- a/nest/src/exceptions/grpc-exception.filter.ts
+++ b/nest/src/exceptions/grpc-exception.filter.ts
@@ -329,7 +329,10 @@ export class GrpcExceptionFilter implements ExceptionFilter {
     if (httpStatus === 401) return status.UNAUTHENTICATED;
     if (httpStatus === 403) return status.PERMISSION_DENIED;
     if (httpStatus === 404) return status.NOT_FOUND;
+    if (httpStatus === 408) return status.DEADLINE_EXCEEDED;
     if (httpStatus === 409) return status.ALREADY_EXISTS;
+    if (httpStatus === 413) return status.RESOURCE_EXHAUSTED;
+    if (httpStatus === 415) return status.INVALID_ARGUMENT;
     if (httpStatus === 422) return status.FAILED_PRECONDITION;
     if (httpStatus === 429) return status.RESOURCE_EXHAUSTED;
     return status.UNKNOWN;

--- a/nest/src/exceptions/grpc-exception.filter.ts
+++ b/nest/src/exceptions/grpc-exception.filter.ts
@@ -324,6 +324,9 @@ export class GrpcExceptionFilter implements ExceptionFilter {
     // 关键区分：
     // - 400 INVALID_ARGUMENT: 请求参数本身有问题（格式错、缺字段），修改参数才能成功
     // - 422 FAILED_PRECONDITION: 请求合法但当前条件不满足（设备不在线、余额不足），换个时机/条件可能成功
+    // - 502/503 UNAVAILABLE: 上游依赖不可用，区别于本服务内部故障
+    if (httpStatus === 502) return status.UNAVAILABLE;
+    if (httpStatus === 503) return status.UNAVAILABLE;
     if (httpStatus >= 500) return status.INTERNAL;
     if (httpStatus === 400) return status.INVALID_ARGUMENT;
     if (httpStatus === 401) return status.UNAUTHENTICATED;

--- a/nest/src/exceptions/oops-factories.spec.ts
+++ b/nest/src/exceptions/oops-factories.spec.ts
@@ -54,7 +54,7 @@ describe('Oops.Block factory methods (4xx)', () => {
   });
 });
 
-describe('Oops.Panic factory methods (500)', () => {
+describe('Oops.Panic factory methods (5xx)', () => {
   it('Panic.Database()', () => {
     const err = Oops.Panic.Database('query timeout');
     expect(err).toBeInstanceOf(Oops.Panic);
@@ -79,6 +79,12 @@ describe('Oops.Panic factory methods (500)', () => {
     const cause = new Error('connection refused');
     const err = Oops.Panic.ExternalService('Redis', 'connection refused', { cause });
     expect(err.cause).toBe(cause);
+  });
+
+  it('Panic.ExternalService() should preserve upstream failure status', () => {
+    const err = Oops.Panic.ExternalService('Azure STT', 'temporarily unavailable', { httpStatus: 503 });
+    expect(err.httpStatus).toBe(503);
+    expect(err.isFatal()).toBe(true);
   });
 
   it('Panic.Config()', () => {

--- a/nest/src/exceptions/oops-factories.ts
+++ b/nest/src/exceptions/oops-factories.ts
@@ -1,6 +1,10 @@
 import { ErrorCodes } from './error-codes';
 import { Oops } from './oops';
 
+import type { PanicHttpStatus } from './oops';
+
+type ExternalServicePanicOptions = { cause?: unknown; httpStatus?: PanicHttpStatus };
+
 // ==================== Oops (422) Factories ====================
 
 /** 通用参数验证失败 */
@@ -164,8 +168,13 @@ Oops.Panic.Database = function (operation: string, options?: { cause?: unknown }
 };
 
 /** 外部服务不可达 — "服务暂时不可用" */
-Oops.Panic.ExternalService = function (service: string, details?: string, options?: { cause?: unknown }): Oops.Panic {
+Oops.Panic.ExternalService = function (
+  service: string,
+  details?: string,
+  options?: ExternalServicePanicOptions,
+): Oops.Panic {
   return new Oops.Panic({
+    httpStatus: options?.httpStatus,
     errorCode: ErrorCodes.EXTERNAL_SERVICE_ERROR,
     userMessage: '服务暂时不可用，请稍后重试',
     internalDetails: `External service error: ${service}${details ? `, ${details}` : ''}`,
@@ -207,7 +216,7 @@ declare module './oops' {
     // Panic (500) factory methods
     namespace Panic {
       function Database(operation: string, options?: { cause?: unknown }): Oops.Panic;
-      function ExternalService(service: string, details?: string, options?: { cause?: unknown }): Oops.Panic;
+      function ExternalService(service: string, details?: string, options?: ExternalServicePanicOptions): Oops.Panic;
       function Config(details: string, options?: { cause?: unknown }): Oops.Panic;
       function AIModelError(model: string, error: string, options?: { cause?: unknown }): Oops.Panic;
       function AIObjectGenerationFailed(

--- a/nest/src/exceptions/oops.spec.ts
+++ b/nest/src/exceptions/oops.spec.ts
@@ -3,6 +3,8 @@ import { OopsError } from './oops-error';
 
 import { describe, expect, it } from 'bun:test';
 
+import type { BlockHttpStatus, PanicHttpStatus } from './oops';
+
 describe('Oops (422)', () => {
   it('should have httpStatus 422', () => {
     const err = new Oops({
@@ -19,7 +21,7 @@ describe('Oops (422)', () => {
 });
 
 describe('Oops.Block (4xx)', () => {
-  it('should accept 401/403/404/409 status', () => {
+  it('should accept existing request-boundary statuses', () => {
     const err = new Oops.Block({
       httpStatus: 401,
       errorCode: '0x0103',
@@ -32,10 +34,28 @@ describe('Oops.Block (4xx)', () => {
     expect(err instanceof Oops.Block).toBe(true);
     expect(err instanceof Oops).toBe(false);
   });
+
+  it('should accept timeout, payload size, and media type statuses as non-fatal request blocks', () => {
+    const statuses: BlockHttpStatus[] = [408, 413, 415];
+
+    for (const httpStatus of statuses) {
+      const err = new Oops.Block({
+        httpStatus,
+        errorCode: '0x0101',
+        oopsCode: 'ST01',
+        userMessage: 'stream request blocked',
+      });
+
+      expect(err.httpStatus).toBe(httpStatus);
+      expect(err.isFatal()).toBe(false);
+      expect(err instanceof OopsError).toBe(true);
+      expect(err instanceof Oops.Block).toBe(true);
+    }
+  });
 });
 
-describe('Oops.Panic (500)', () => {
-  it('should have httpStatus 500 and be fatal', () => {
+describe('Oops.Panic (5xx)', () => {
+  it('should default httpStatus to 500 and be fatal', () => {
     const err = new Oops.Panic({
       errorCode: '0x0401',
       oopsCode: 'SY01',
@@ -47,6 +67,24 @@ describe('Oops.Panic (500)', () => {
     expect(err instanceof OopsError).toBe(true);
     expect(err instanceof Oops.Panic).toBe(true);
     expect(err instanceof Oops).toBe(false);
+  });
+
+  it('should accept upstream failure statuses and remain fatal', () => {
+    const statuses: PanicHttpStatus[] = [502, 503];
+
+    for (const httpStatus of statuses) {
+      const err = new Oops.Panic({
+        httpStatus,
+        errorCode: '0x0401',
+        oopsCode: 'SY02',
+        userMessage: 'upstream failed',
+      });
+
+      expect(err.httpStatus).toBe(httpStatus);
+      expect(err.isFatal()).toBe(true);
+      expect(err instanceof OopsError).toBe(true);
+      expect(err instanceof Oops.Panic).toBe(true);
+    }
   });
 
   it('should default oopsCode to empty string', () => {

--- a/nest/src/exceptions/oops.ts
+++ b/nest/src/exceptions/oops.ts
@@ -14,11 +14,16 @@ interface OopsConfig {
   cause?: unknown;
 }
 
+type BlockHttpStatus = 400 | 401 | 403 | 404 | 408 | 409 | 413 | 415 | 429;
+type PanicHttpStatus = 500 | 502 | 503;
+
 interface BlockConfig extends OopsConfig {
-  httpStatus: 400 | 401 | 403 | 404 | 409 | 429;
+  httpStatus: BlockHttpStatus;
 }
 
 interface PanicConfig {
+  /** Defaults to 500; use 502/503 when preserving upstream dependency failure semantics. */
+  httpStatus?: PanicHttpStatus;
   errorCode: ErrorCodeValue;
   oopsCode?: string;
   userMessage: string;
@@ -64,7 +69,7 @@ namespace Oops {
    * WARN 日志，不触发 Sentry。
    */
   export class Block extends OopsError {
-    readonly httpStatus: 400 | 401 | 403 | 404 | 409 | 429;
+    readonly httpStatus: BlockHttpStatus;
     readonly errorCode: ErrorCodeValue;
     readonly oopsCode: string;
     readonly userMessage: string;
@@ -83,13 +88,14 @@ namespace Oops {
   }
 
   /**
-   * 系统故障 — 500 Internal Server Error
+   * 系统故障 — 5xx server / upstream failure
    *
    * 大楼停电了：DB 挂了、外部服务不可达、配置缺失。
+   * 缺省 500；上游依赖失败可显式标 502/503。
    * ERROR 日志，触发 Sentry。
    */
   export class Panic extends OopsError {
-    readonly httpStatus = 500 as const;
+    readonly httpStatus: PanicHttpStatus;
     readonly errorCode: ErrorCodeValue;
     readonly oopsCode: string;
     readonly userMessage: string;
@@ -98,6 +104,7 @@ namespace Oops {
 
     constructor(config: PanicConfig) {
       super(config.internalDetails ?? config.userMessage, { cause: config.cause });
+      this.httpStatus = config.httpStatus ?? 500;
       this.errorCode = config.errorCode;
       this.oopsCode = config.oopsCode ?? '';
       this.userMessage = config.userMessage;
@@ -108,4 +115,4 @@ namespace Oops {
 }
 
 export { Oops };
-export type { OopsConfig, BlockConfig, PanicConfig };
+export type { OopsConfig, BlockConfig, PanicConfig, BlockHttpStatus, PanicHttpStatus };


### PR DESCRIPTION
## Summary
- add shared Block/Panic HTTP status type contracts
- allow Oops.Block to represent request timeout, payload-too-large, and unsupported media-type failures
- allow Oops.Panic to preserve upstream 502/503 failures while defaulting to 500
- let Oops.Panic.ExternalService carry an upstream failure status

## Validation
- bun test nest/src/exceptions
- bun run typecheck
- prettier --check related exception files
- eslint related source files
- pre-commit and pre-push full checks: tsc, eslint, bun test