### PR TITLE
Align framework gaps from Shawn diff

### DIFF
--- a/features/llm/clients/llm.tier.spec.ts
+++ b/features/llm/clients/llm.tier.spec.ts
@@ -119,6 +119,11 @@ describe('getSupportedTiers', () => {
     expect(tiers).toEqual(['standard', 'flex', 'priority']);
   });
 
+  it('returns [standard, flex, priority] for vertex:gemini-3.5-flash (regional PayGo lists)', () => {
+    const tiers = getSupportedTiers('vertex:gemini-3.5-flash');
+    expect(tiers).toEqual(['standard', 'flex', 'priority']);
+  });
+
   it('returns [standard, flex, priority] for vertex-global:gemini-3.5-flash (global PayGo lists)', () => {
     const tiers = getSupportedTiers('vertex-global:gemini-3.5-flash');
     expect(tiers).toEqual(['standard', 'flex', 'priority']);
@@ -160,6 +165,16 @@ describe('buildTierHeaders: supported tiers emit header', () => {
   it('flex on gemini-3-flash-preview → emits flex header', () => {
     const headers = buildTierHeaders('vertex:gemini-3-flash-preview', 'flex');
     expect(headers).toEqual({ [VERTEX_TIER_HEADER]: 'flex' });
+  });
+
+  it('flex on regional gemini-3.5-flash → emits flex header', () => {
+    const headers = buildTierHeaders('vertex:gemini-3.5-flash', 'flex');
+    expect(headers).toEqual({ [VERTEX_TIER_HEADER]: 'flex' });
+  });
+
+  it('priority on regional gemini-3.5-flash → emits priority header', () => {
+    const headers = buildTierHeaders('vertex:gemini-3.5-flash', 'priority');
+    expect(headers).toEqual({ [VERTEX_TIER_HEADER]: 'priority' });
   });
 
   it('priority on gemini-2.5-flash → emits priority header', () => {

--- a/features/llm/clients/llm.tier.spec.ts
+++ b/features/llm/clients/llm.tier.spec.ts
@@ -119,6 +119,11 @@ describe('getSupportedTiers', () => {
     expect(tiers).toEqual(['standard', 'flex', 'priority']);
   });
 
+  it('returns [standard, flex, priority] for vertex-global:gemini-3.5-flash (global PayGo lists)', () => {
+    const tiers = getSupportedTiers('vertex-global:gemini-3.5-flash');
+    expect(tiers).toEqual(['standard', 'flex', 'priority']);
+  });
+
   it('returns [standard] for openrouter models (not a vertex concept)', () => {
     const tiers = getSupportedTiers('openrouter:gemini-2.5-flash');
     expect(tiers).toEqual(['standard']);
@@ -164,6 +169,16 @@ describe('buildTierHeaders: supported tiers emit header', () => {
 
   it('priority on vertex-global gemini-2.5-flash → emits priority header', () => {
     const headers = buildTierHeaders('vertex-global:gemini-2.5-flash', 'priority');
+    expect(headers).toEqual({ [VERTEX_TIER_HEADER]: 'priority' });
+  });
+
+  it('flex on vertex-global gemini-3.5-flash → emits flex header', () => {
+    const headers = buildTierHeaders('vertex-global:gemini-3.5-flash', 'flex');
+    expect(headers).toEqual({ [VERTEX_TIER_HEADER]: 'flex' });
+  });
+
+  it('priority on vertex-global gemini-3.5-flash → emits priority header', () => {
+    const headers = buildTierHeaders('vertex-global:gemini-3.5-flash', 'priority');
     expect(headers).toEqual({ [VERTEX_TIER_HEADER]: 'priority' });
   });
 

--- a/features/llm/types/model.types.spec.ts
+++ b/features/llm/types/model.types.spec.ts
@@ -187,6 +187,16 @@ describe('getModel', () => {
     const config = getModel(`${KNOWN_KEY}?reason=high&retry=3` as LLMModelSpec);
     expect(config.provider).toBe('openrouter');
   });
+
+  it('should return Vertex direct Gemini 3.5 Flash variants', () => {
+    const regional = getModel('vertex:gemini-3.5-flash');
+    const global = getModel('vertex-global:gemini-3.5-flash');
+
+    expect(regional.provider).toBe('vertex');
+    expect(regional.modelId).toBe('gemini-3.5-flash');
+    expect(global.provider).toBe('vertex-global');
+    expect(global.modelId).toBe('gemini-3.5-flash');
+  });
 });
 
 describe('getModelId', () => {
@@ -194,6 +204,11 @@ describe('getModelId', () => {
     const id = getModelId(KNOWN_KEY);
     expect(typeof id).toBe('string');
     expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('should return modelId for Vertex direct Gemini 3.5 Flash variants', () => {
+    expect(getModelId('vertex:gemini-3.5-flash')).toBe('gemini-3.5-flash');
+    expect(getModelId('vertex-global:gemini-3.5-flash')).toBe('gemini-3.5-flash');
   });
 });
 

--- a/features/llm/types/model.types.ts
+++ b/features/llm/types/model.types.ts
@@ -887,7 +887,10 @@ const modelRegistry = new Map<string, ModelConfig>([
       supportedTiers: ['standard', 'flex', 'priority'],
     },
   ],
-  ['vertex:gemini-3.5-flash', { provider: 'vertex', modelId: 'gemini-3.5-flash' }],
+  [
+    'vertex:gemini-3.5-flash',
+    { provider: 'vertex', modelId: 'gemini-3.5-flash', supportedTiers: ['standard', 'flex', 'priority'] },
+  ],
   [
     'vertex:gemini-3.1-pro-preview',
     {

--- a/features/llm/types/model.types.ts
+++ b/features/llm/types/model.types.ts
@@ -923,7 +923,10 @@ const modelRegistry = new Map<string, ModelConfig>([
       supportedTiers: ['standard', 'flex', 'priority'],
     },
   ],
-  ['vertex-global:gemini-3.5-flash', { provider: 'vertex-global', modelId: 'gemini-3.5-flash' }],
+  [
+    'vertex-global:gemini-3.5-flash',
+    { provider: 'vertex-global', modelId: 'gemini-3.5-flash', supportedTiers: ['standard', 'flex', 'priority'] },
+  ],
   [
     'vertex-global:gemini-3.1-pro-preview',
     {

--- a/features/llm/types/model.types.ts
+++ b/features/llm/types/model.types.ts
@@ -535,6 +535,7 @@ export interface LLMModelRegistry {
   'vertex:gemini-2.5-flash-lite': ModelConfig<'vertex'>;
   'vertex:gemini-3-flash-preview': ModelConfig<'vertex'>;
   'vertex:gemini-3.1-flash-lite': ModelConfig<'vertex'>;
+  'vertex:gemini-3.5-flash': ModelConfig<'vertex'>;
   'vertex:gemini-3.1-pro-preview': ModelConfig<'vertex'>;
 
   // ==================== Vertex AI (project/global mode) ====================
@@ -543,6 +544,7 @@ export interface LLMModelRegistry {
   'vertex-global:gemini-2.5-flash-lite': ModelConfig<'vertex-global'>;
   'vertex-global:gemini-3-flash-preview': ModelConfig<'vertex-global'>;
   'vertex-global:gemini-3.1-flash-lite': ModelConfig<'vertex-global'>;
+  'vertex-global:gemini-3.5-flash': ModelConfig<'vertex-global'>;
   'vertex-global:gemini-3.1-pro-preview': ModelConfig<'vertex-global'>;
 }
 
@@ -885,6 +887,7 @@ const modelRegistry = new Map<string, ModelConfig>([
       supportedTiers: ['standard', 'flex', 'priority'],
     },
   ],
+  ['vertex:gemini-3.5-flash', { provider: 'vertex', modelId: 'gemini-3.5-flash' }],
   [
     'vertex:gemini-3.1-pro-preview',
     {
@@ -920,6 +923,7 @@ const modelRegistry = new Map<string, ModelConfig>([
       supportedTiers: ['standard', 'flex', 'priority'],
     },
   ],
+  ['vertex-global:gemini-3.5-flash', { provider: 'vertex-global', modelId: 'gemini-3.5-flash' }],
   [
     'vertex-global:gemini-3.1-pro-preview',
     {

--- a/nest/src/exceptions/any-exception.filter.spec.ts
+++ b/nest/src/exceptions/any-exception.filter.spec.ts
@@ -17,6 +17,9 @@ import {
 } from '@nestjs/common';
 import { ThrottlerException } from '@nestjs/throttler';
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { GraphQLError } from 'graphql';
 import { ZodError } from 'zod';
@@ -570,6 +573,22 @@ describe('AnyExceptionFilter', () => {
       );
     });
 
+    it('headers 缺失时 fallback 到 typed request.user.preferredLocale', async () => {
+      const { filter: filterWithI18n, translateErrorMessage } = createI18nFilter();
+      const request = createMockRequest({
+        preferredLocale: ' zh-Hant ',
+      }) as ReturnType<typeof createMockRequest> & { headers?: Record<string, string> };
+      Reflect.deleteProperty(request, 'headers');
+
+      await filterWithI18n.catch(Oops.Validation('原始消息'), createHttpHost({ request }).host);
+
+      expect(translateErrorMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetLanguage: 'zh-Hant',
+        }),
+      );
+    });
+
     it('空 x-locale 和 wildcard x-locale fallback 到 preferredLocale', async () => {
       const emptyCase = createI18nFilter();
       await emptyCase.filter.catch(
@@ -651,6 +670,12 @@ describe('toErrorDescriptor', () => {
     const desc = toErrorDescriptor(new ThrottlerException('too many'));
     expect(desc?.httpStatus).toBe(HttpStatus.TOO_MANY_REQUESTS);
     expect(desc?.code).toBe(ErrorCodes.CLIENT_RATE_LIMITED);
+  });
+
+  it('error-descriptor does not import optional throttler at module scope', () => {
+    const source = readFileSync(join(process.cwd(), 'nest/src/exceptions/error-descriptor.ts'), 'utf8');
+
+    expect(source).not.toContain('@nestjs/throttler');
   });
 
   it('UnprocessableEntityException + BUSINESS_RULE_VIOLATION cause → warning', () => {

--- a/nest/src/exceptions/any-exception.filter.ts
+++ b/nest/src/exceptions/any-exception.filter.ts
@@ -31,6 +31,10 @@ type OopsLike = {
   getInternalDetails(): string;
 };
 
+type LocaleRequestLike = Omit<IdentityRequest, 'headers'> & {
+  headers?: IdentityRequest['headers'];
+};
+
 /**
  * ⚠️  ErrorCodes 迁移说明（针对其他项目）
  *
@@ -370,7 +374,7 @@ export class AnyExceptionFilter implements ExceptionFilter {
    * - 不做任何语言判断、规范化
    * - 所有语言逻辑交给 i18nService.translateErrorMessage 统一处理
    */
-  private async getTranslatedMessage(exception: OopsLike, request?: IdentityRequest): Promise<string> {
+  private async getTranslatedMessage(exception: OopsLike, request?: LocaleRequestLike): Promise<string> {
     try {
       const i18nService = this.getI18nService();
       if (!i18nService) {
@@ -403,12 +407,13 @@ export class AnyExceptionFilter implements ExceptionFilter {
    * - 返回 null 表示没有可用语言信号
    * - 所有语言逻辑交给 i18nService 处理
    */
-  private getLocaleFromRequest(request?: IdentityRequest): string | null {
+  private getLocaleFromRequest(request?: LocaleRequestLike): string | null {
     if (!request) {
       return null;
     }
 
-    const xLocale = request.headers['x-locale'];
+    const headers = request.headers ?? {};
+    const xLocale = headers['x-locale'];
 
     if (typeof xLocale === 'string') {
       const trimmed = xLocale.trim();

--- a/nest/src/exceptions/any-exception.filter.ts
+++ b/nest/src/exceptions/any-exception.filter.ts
@@ -1,33 +1,27 @@
-import {
-  BadRequestException,
-  ConflictException,
-  HttpException,
-  NotFoundException,
-  UnauthorizedException,
-  UnprocessableEntityException,
-} from '@nestjs/common';
 import { HttpStatus } from '@nestjs/common/enums';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { ThrottlerException } from '@nestjs/throttler';
 
 import { SysEnv } from '@app/env';
 import { ApiRes } from '@app/nest/common/response';
 import { ErrorCodes } from '@app/nest/exceptions/error-codes';
 import { getAppLogger } from '@app/utils/app-logger';
-import { getErrorMessage, getErrorName, getErrorStatus, getResponseMessage } from '@app/utils/error';
+import { getErrorMessage, getErrorName, getErrorStatus } from '@app/utils/error';
 
+import { isServerError, toErrorDescriptor } from './error-descriptor';
 import { OopsError } from './oops-error';
 
 import { SentryExceptionCaptured } from '@sentry/nestjs';
 import { GraphQLError } from 'graphql';
 import * as _ from 'radash';
-import { ZodError } from 'zod';
 
 import type { IdentityRequest } from '../types/identity.interface';
+import type { HttpErrorDescriptor } from './error-descriptor';
 import type { II18nService } from '@app/nest/common/i18n.interface';
-import type { ErrorCodeValue } from '@app/nest/exceptions/error-codes';
 import type { ArgumentsHost, ExceptionFilter, ExecutionContext, INestApplication } from '@nestjs/common';
 import type { Response } from 'express';
+
+export { toErrorDescriptor } from './error-descriptor';
+export type { HttpErrorDescriptor } from './error-descriptor';
 
 /** OopsError 或兼容旧 OopsLike 的鸭子类型 */
 type OopsLike = {
@@ -414,7 +408,7 @@ export class AnyExceptionFilter implements ExceptionFilter {
       return null;
     }
 
-    const xLocale = request.headers?.['x-locale'];
+    const xLocale = request.headers['x-locale'];
 
     if (typeof xLocale === 'string') {
       const trimmed = xLocale.trim();
@@ -446,206 +440,4 @@ function maskConnectionParams(params: Record<string, unknown>) {
     }
   }
   return clone;
-}
-
-function isValidErrorCode(code: unknown): code is ErrorCodeValue {
-  return Object.values(ErrorCodes).includes(code as ErrorCodes);
-}
-
-/**
- * 判断是否为 Prisma 已知请求错误（鸭子类型，不依赖 Prisma 导入）
- *
- * PrismaClientKnownRequestError 结构特征：
- * - code: 'P2002' 等以 'P' 开头的错误码
- * - clientVersion: Prisma 版本字符串
- * - name: 'PrismaClientKnownRequestError'
- */
-interface PrismaKnownRequestError {
-  code: string;
-  message: string;
-  clientVersion?: string;
-  meta?: unknown;
-}
-
-/** 通过 `number` 注解将 enum 字面量类型放宽为 number，避免 `no-unsafe-enum-comparison` 同时不触发 `no-unnecessary-type-assertion`。 */
-const SERVER_ERROR_MIN: number = HttpStatus.INTERNAL_SERVER_ERROR;
-function isServerError(status: number): boolean {
-  return status >= SERVER_ERROR_MIN;
-}
-
-function isPrismaKnownRequestError(e: unknown): e is PrismaKnownRequestError {
-  if (typeof e !== 'object' || e === null) return false;
-
-  const err = e as Record<string, unknown>;
-
-  // 检查错误码是否以 'P' 开头（Prisma 约定）
-  if (typeof err.code !== 'string' || !err.code.startsWith('P')) return false;
-
-  // 检查是否有 clientVersion（Prisma 特有）
-  if ('clientVersion' in err && typeof err.clientVersion === 'string') return true;
-
-  // 检查构造函数名称（备用方案）
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- constructor 来自原型链，Object.create(null) 时不存在
-  if (err.constructor?.name === 'PrismaClientKnownRequestError') return true;
-
-  return false;
-}
-
-/**
- * 异常到响应描述符的统一映射结果
- *
- * HTTP 分支拿它填 `ApiRes.failure` + `response.status(httpStatus)`，
- * GraphQL 分支拿它填 `GraphQLError(message, { extensions: { httpStatus, code, userMessage } })`。
- * 两个协议共享同一套"异常 → 状态/码/消息"的映射规则，避免两边漂移。
- */
-export interface HttpErrorDescriptor {
-  httpStatus: number;
-  code: string;
-  message: string;
-  errors?: unknown;
-  /**
-   * 日志级别。绝大多数情况下 = httpStatus >= 500 ? 'error' : 'warning'，
-   * UnprocessableEntityException 例外：某些 cause 语义是业务预期（warning），
-   * 其他 cause 视为未预期错误（error）。
-   */
-  logLevel: 'warning' | 'error';
-}
-
-/**
- * 把"协议层"异常（HttpException 家族 + Zod / Prisma / FetchError）映射为统一的
- * HttpErrorDescriptor。返回 `null` 表示这是未识别的异常，调用方应走 500 兜底 + Sentry。
- *
- * 设计决策：
- * - OopsError / Legacy BusinessException **不**进入此函数 —— 它们走 handleBusinessException
- *   / handleGraphqlBusinessException，这些方法会做 i18n 翻译 + 细分日志，映射规则不同。
- * - Pure function，不做日志、不触发 Sentry，仅做数据转换。副作用由调用方执行，便于单元测试。
- * - 新增异常类型时只需在此添加一个 branch，HTTP/GraphQL 两条响应路径自动对齐。
- */
-export function toErrorDescriptor(exception: unknown): HttpErrorDescriptor | null {
-  if (exception instanceof ZodError) {
-    return {
-      httpStatus: HttpStatus.BAD_REQUEST,
-      code: ErrorCodes.CLIENT_VALIDATION_FAILED,
-      message: 'Invalid parameters',
-      errors: exception.issues,
-      logLevel: 'warning',
-    };
-  }
-
-  if (exception instanceof BadRequestException) {
-    return {
-      httpStatus: HttpStatus.BAD_REQUEST,
-      code: ErrorCodes.CLIENT_INPUT_ERROR,
-      message: exception.message,
-      errors: getResponseMessage(exception.getResponse()),
-      logLevel: 'warning',
-    };
-  }
-
-  if (isPrismaKnownRequestError(exception)) {
-    return {
-      httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
-      code: ErrorCodes.SYSTEM_DATABASE_ERROR,
-      message: 'Operation failed, please try again later',
-      logLevel: 'warning',
-    };
-  }
-
-  if (exception instanceof ThrottlerException) {
-    return {
-      httpStatus: HttpStatus.TOO_MANY_REQUESTS,
-      code: ErrorCodes.CLIENT_RATE_LIMITED,
-      message: exception.message,
-      errors: getResponseMessage(exception.getResponse()),
-      logLevel: 'warning',
-    };
-  }
-
-  if (exception instanceof NotFoundException) {
-    return {
-      httpStatus: HttpStatus.NOT_FOUND,
-      code: ErrorCodes.CLIENT_AUTH_REQUIRED,
-      message: exception.message,
-      errors: getResponseMessage(exception.getResponse()),
-      logLevel: 'warning',
-    };
-  }
-
-  if (getErrorName(exception) === 'FetchError') {
-    return {
-      httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
-      code: ErrorCodes.EXTERNAL_SERVICE_ERROR,
-      message: 'Service temporarily unavailable',
-      logLevel: 'warning',
-    };
-  }
-
-  if (exception instanceof UnauthorizedException) {
-    return {
-      httpStatus: HttpStatus.UNAUTHORIZED,
-      code: ErrorCodes.CLIENT_AUTH_REQUIRED,
-      message: exception.message,
-      errors: getResponseMessage(exception.getResponse()),
-      logLevel: 'warning',
-    };
-  }
-
-  if (exception instanceof ConflictException) {
-    return {
-      httpStatus: HttpStatus.CONFLICT,
-      code: ErrorCodes.BUSINESS_DATA_CONFLICT,
-      message: exception.message,
-      errors: getResponseMessage(exception.getResponse()),
-      logLevel: 'warning',
-    };
-  }
-
-  if (exception instanceof UnprocessableEntityException) {
-    const rawCause = exception.cause;
-    const code = isValidErrorCode(rawCause) ? rawCause : ErrorCodes.SYSTEM_INTERNAL_ERROR;
-    // 业务预期的 422（数据冲突、业务规则）记 warning；其他 cause 视为未预期，记 error
-    const warnCodes: ErrorCodeValue[] = [ErrorCodes.DATA_VERSION_MISMATCH, ErrorCodes.BUSINESS_RULE_VIOLATION];
-    return {
-      httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
-      code,
-      message: exception.message,
-      errors: getResponseMessage(exception.getResponse()),
-      logLevel: warnCodes.includes(code) ? 'warning' : 'error',
-    };
-  }
-
-  // 注意：HttpException 分支必须放在最后。BadRequest / Unauthorized / NotFound / Conflict /
-  // Throttler / UnprocessableEntity 都继承自 HttpException，提前匹配会吃掉它们的细分 code 映射。
-  if (exception instanceof HttpException) {
-    const status = exception.getStatus();
-    const responseBody = exception.getResponse();
-    const responseMessage = getResponseMessage(responseBody);
-    const message: string =
-      typeof responseBody === 'string'
-        ? responseBody
-        : typeof responseMessage === 'string'
-          ? responseMessage
-          : exception.message;
-
-    if (!isServerError(status)) {
-      return {
-        httpStatus: status,
-        code: ErrorCodes.CLIENT_INPUT_ERROR,
-        message,
-        errors: typeof responseBody === 'object' ? responseMessage : undefined,
-        logLevel: 'warning',
-      };
-    }
-
-    // 5xx HttpException：调用方负责触发 Sentry
-    const body = typeof responseBody === 'object' ? (responseBody as Record<string, unknown>) : {};
-    return {
-      httpStatus: status,
-      code: typeof body.code === 'string' ? body.code : ErrorCodes.SYSTEM_INTERNAL_ERROR,
-      message: typeof body.message === 'string' ? body.message : 'Internal server error, please try again later',
-      logLevel: 'error',
-    };
-  }
-
-  return null;
 }

--- a/nest/src/exceptions/error-descriptor.ts
+++ b/nest/src/exceptions/error-descriptor.ts
@@ -1,0 +1,217 @@
+import {
+  BadRequestException,
+  ConflictException,
+  HttpException,
+  NotFoundException,
+  UnauthorizedException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common/enums';
+import { ThrottlerException } from '@nestjs/throttler';
+
+import { getErrorName, getResponseMessage } from '@app/utils/error';
+
+import { ErrorCodes, isValidErrorCode } from './error-codes';
+
+import { ZodError } from 'zod';
+
+import type { ErrorCodeValue } from './error-codes';
+
+/**
+ * 异常到响应描述符的统一映射结果
+ *
+ * HTTP 分支拿它填 `ApiRes.failure` + `response.status(httpStatus)`，
+ * GraphQL 分支拿它填 `GraphQLError(message, { extensions: { httpStatus, code, userMessage } })`，
+ * gRPC 分支拿它填 `{ code, details }`。
+ * 三个协议共享同一套"异常 → 状态/码/消息"的映射规则，避免两边漂移。
+ */
+export interface HttpErrorDescriptor {
+  httpStatus: number;
+  code: string;
+  message: string;
+  errors?: unknown;
+  /**
+   * 日志级别。绝大多数情况下 = httpStatus >= 500 ? 'error' : 'warning'，
+   * UnprocessableEntityException 例外：某些 cause 语义是业务预期（warning），
+   * 其他 cause 视为未预期错误（error）。
+   */
+  logLevel: 'warning' | 'error';
+}
+
+/**
+ * 判断是否为 Prisma 已知请求错误（鸭子类型，不依赖 Prisma 导入）
+ *
+ * PrismaClientKnownRequestError 结构特征：
+ * - code: 'P2002' 等以 'P' 开头的错误码
+ * - clientVersion: Prisma 版本字符串
+ * - name: 'PrismaClientKnownRequestError'
+ */
+interface PrismaKnownRequestError {
+  code: string;
+  message: string;
+  clientVersion?: string;
+  meta?: unknown;
+}
+
+/** 通过 `number` 注解将 enum 字面量类型放宽为 number，避免 `no-unsafe-enum-comparison` 同时不触发 `no-unnecessary-type-assertion`。 */
+const SERVER_ERROR_MIN: number = HttpStatus.INTERNAL_SERVER_ERROR;
+export function isServerError(status: number): boolean {
+  return status >= SERVER_ERROR_MIN;
+}
+
+function isPrismaKnownRequestError(e: unknown): e is PrismaKnownRequestError {
+  if (typeof e !== 'object' || e === null) return false;
+
+  const err = e as Record<string, unknown>;
+
+  // 检查错误码是否以 'P' 开头（Prisma 约定）
+  if (typeof err.code !== 'string' || !err.code.startsWith('P')) return false;
+
+  // 检查是否有 clientVersion（Prisma 特有）
+  if ('clientVersion' in err && typeof err.clientVersion === 'string') return true;
+
+  // 检查构造函数名称（备用方案）
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- constructor 来自原型链，Object.create(null) 时不存在
+  if (err.constructor?.name === 'PrismaClientKnownRequestError') return true;
+
+  return false;
+}
+
+/**
+ * 把"协议层"异常（HttpException 家族 + Zod / Prisma / FetchError）映射为统一的
+ * HttpErrorDescriptor。返回 `null` 表示这是未识别的异常，调用方应走 500 兜底 + Sentry。
+ *
+ * 设计决策：
+ * - OopsError / Legacy BusinessException **不**进入此函数 —— 它们走各协议自己的 Oops
+ *   处理逻辑，这些方法会做 i18n 翻译 + 细分日志，映射规则不同。
+ * - Pure function，不做日志、不触发 Sentry，仅做数据转换。副作用由调用方执行，便于单元测试。
+ * - 新增异常类型时只需在此添加一个 branch，HTTP/GraphQL/gRPC 响应路径自动对齐。
+ */
+export function toErrorDescriptor(exception: unknown): HttpErrorDescriptor | null {
+  if (exception instanceof ZodError) {
+    return {
+      httpStatus: HttpStatus.BAD_REQUEST,
+      code: ErrorCodes.CLIENT_VALIDATION_FAILED,
+      message: 'Invalid parameters',
+      errors: exception.issues,
+      logLevel: 'warning',
+    };
+  }
+
+  if (exception instanceof BadRequestException) {
+    return {
+      httpStatus: HttpStatus.BAD_REQUEST,
+      code: ErrorCodes.CLIENT_INPUT_ERROR,
+      message: exception.message,
+      errors: getResponseMessage(exception.getResponse()),
+      logLevel: 'warning',
+    };
+  }
+
+  if (isPrismaKnownRequestError(exception)) {
+    return {
+      httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+      code: ErrorCodes.SYSTEM_DATABASE_ERROR,
+      message: 'Operation failed, please try again later',
+      logLevel: 'warning',
+    };
+  }
+
+  if (exception instanceof ThrottlerException) {
+    return {
+      httpStatus: HttpStatus.TOO_MANY_REQUESTS,
+      code: ErrorCodes.CLIENT_RATE_LIMITED,
+      message: exception.message,
+      errors: getResponseMessage(exception.getResponse()),
+      logLevel: 'warning',
+    };
+  }
+
+  if (exception instanceof NotFoundException) {
+    return {
+      httpStatus: HttpStatus.NOT_FOUND,
+      code: ErrorCodes.CLIENT_AUTH_REQUIRED,
+      message: exception.message,
+      errors: getResponseMessage(exception.getResponse()),
+      logLevel: 'warning',
+    };
+  }
+
+  if (getErrorName(exception) === 'FetchError') {
+    return {
+      httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+      code: ErrorCodes.EXTERNAL_SERVICE_ERROR,
+      message: 'Service temporarily unavailable',
+      logLevel: 'warning',
+    };
+  }
+
+  if (exception instanceof UnauthorizedException) {
+    return {
+      httpStatus: HttpStatus.UNAUTHORIZED,
+      code: ErrorCodes.CLIENT_AUTH_REQUIRED,
+      message: exception.message,
+      errors: getResponseMessage(exception.getResponse()),
+      logLevel: 'warning',
+    };
+  }
+
+  if (exception instanceof ConflictException) {
+    return {
+      httpStatus: HttpStatus.CONFLICT,
+      code: ErrorCodes.BUSINESS_DATA_CONFLICT,
+      message: exception.message,
+      errors: getResponseMessage(exception.getResponse()),
+      logLevel: 'warning',
+    };
+  }
+
+  if (exception instanceof UnprocessableEntityException) {
+    const rawCause = exception.cause;
+    const code = isValidErrorCode(rawCause) ? rawCause : ErrorCodes.SYSTEM_INTERNAL_ERROR;
+    // 业务预期的 422（数据冲突、业务规则）记 warning；其他 cause 视为未预期，记 error
+    const warnCodes: ErrorCodeValue[] = [ErrorCodes.DATA_VERSION_MISMATCH, ErrorCodes.BUSINESS_RULE_VIOLATION];
+    return {
+      httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+      code,
+      message: exception.message,
+      errors: getResponseMessage(exception.getResponse()),
+      logLevel: warnCodes.includes(code) ? 'warning' : 'error',
+    };
+  }
+
+  // 注意：HttpException 分支必须放在最后。BadRequest / Unauthorized / NotFound / Conflict /
+  // Throttler / UnprocessableEntity 都继承自 HttpException，提前匹配会吃掉它们的细分 code 映射。
+  if (exception instanceof HttpException) {
+    const status = exception.getStatus();
+    const responseBody = exception.getResponse();
+    const responseMessage = getResponseMessage(responseBody);
+    const message: string =
+      typeof responseBody === 'string'
+        ? responseBody
+        : typeof responseMessage === 'string'
+          ? responseMessage
+          : exception.message;
+
+    if (!isServerError(status)) {
+      return {
+        httpStatus: status,
+        code: ErrorCodes.CLIENT_INPUT_ERROR,
+        message,
+        errors: typeof responseBody === 'object' ? responseMessage : undefined,
+        logLevel: 'warning',
+      };
+    }
+
+    // 5xx HttpException：调用方负责触发 Sentry
+    const body = typeof responseBody === 'object' ? (responseBody as Record<string, unknown>) : {};
+    return {
+      httpStatus: status,
+      code: typeof body.code === 'string' ? body.code : ErrorCodes.SYSTEM_INTERNAL_ERROR,
+      message: typeof body.message === 'string' ? body.message : 'Internal server error, please try again later',
+      logLevel: 'error',
+    };
+  }
+
+  return null;
+}

--- a/nest/src/exceptions/error-descriptor.ts
+++ b/nest/src/exceptions/error-descriptor.ts
@@ -7,7 +7,6 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { HttpStatus } from '@nestjs/common/enums';
-import { ThrottlerException } from '@nestjs/throttler';
 
 import { getErrorName, getResponseMessage } from '@app/utils/error';
 
@@ -77,6 +76,10 @@ function isPrismaKnownRequestError(e: unknown): e is PrismaKnownRequestError {
   return false;
 }
 
+function isThrottlerException(exception: unknown): exception is HttpException {
+  return exception instanceof HttpException && getErrorName(exception) === 'ThrottlerException';
+}
+
 /**
  * 把"协议层"异常（HttpException 家族 + Zod / Prisma / FetchError）映射为统一的
  * HttpErrorDescriptor。返回 `null` 表示这是未识别的异常，调用方应走 500 兜底 + Sentry。
@@ -117,7 +120,7 @@ export function toErrorDescriptor(exception: unknown): HttpErrorDescriptor | nul
     };
   }
 
-  if (exception instanceof ThrottlerException) {
+  if (isThrottlerException(exception)) {
     return {
       httpStatus: HttpStatus.TOO_MANY_REQUESTS,
       code: ErrorCodes.CLIENT_RATE_LIMITED,

--- a/nest/src/exceptions/grpc-exception.filter.spec.ts
+++ b/nest/src/exceptions/grpc-exception.filter.spec.ts
@@ -1,8 +1,10 @@
+import { ErrorCodes } from './error-codes';
 import { GrpcExceptionFilter } from './grpc-exception.filter';
 import { Oops } from './oops';
 
 import './oops-factories';
 
+import { HttpException, HttpStatus, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';
 
 import { Metadata, status } from '@grpc/grpc-js';
@@ -128,6 +130,73 @@ describe('GrpcExceptionFilter', () => {
       } catch (error: unknown) {
         const grpcError = error as { code: number };
         expect(grpcError.code).toBe(status.INVALID_ARGUMENT);
+      }
+    });
+  });
+
+  describe('HttpException', () => {
+    it('should map UnauthorizedException to UNAUTHENTICATED', async () => {
+      const { host } = mockGrpcHost();
+      const result$ = filter.catch(new UnauthorizedException('not logged in'), host);
+
+      try {
+        await firstValueFrom(result$);
+        expect.unreachable('expected HttpException to be thrown as gRPC error');
+      } catch (error: unknown) {
+        const grpcError = error as { code: number; details: string };
+        expect(grpcError.code).toBe(status.UNAUTHENTICATED);
+        const parsed = JSON.parse(grpcError.details) as { httpStatus: number; errorCode: string; businessCode: string };
+        expect(parsed.httpStatus).toBe(HttpStatus.UNAUTHORIZED);
+        expect(parsed.errorCode).toBe(ErrorCodes.CLIENT_AUTH_REQUIRED);
+        expect(parsed.businessCode).toBe(ErrorCodes.CLIENT_AUTH_REQUIRED);
+      }
+    });
+
+    it('should map NotFoundException to NOT_FOUND', async () => {
+      const { host } = mockGrpcHost();
+      const result$ = filter.catch(new NotFoundException('resource not found'), host);
+
+      try {
+        await firstValueFrom(result$);
+        expect.unreachable('expected HttpException to be thrown as gRPC error');
+      } catch (error: unknown) {
+        const grpcError = error as { code: number; details: string };
+        expect(grpcError.code).toBe(status.NOT_FOUND);
+        const parsed = JSON.parse(grpcError.details) as { httpStatus: number; errorCode: string };
+        expect(parsed.httpStatus).toBe(HttpStatus.NOT_FOUND);
+        expect(parsed.errorCode).toBe(ErrorCodes.CLIENT_AUTH_REQUIRED);
+      }
+    });
+
+    it('should map generic 4xx HttpException to INVALID_ARGUMENT', async () => {
+      const { host } = mockGrpcHost();
+      const result$ = filter.catch(new HttpException('not acceptable', HttpStatus.NOT_ACCEPTABLE), host);
+
+      try {
+        await firstValueFrom(result$);
+        expect.unreachable('expected HttpException to be thrown as gRPC error');
+      } catch (error: unknown) {
+        const grpcError = error as { code: number; details: string };
+        expect(grpcError.code).toBe(status.INVALID_ARGUMENT);
+        const parsed = JSON.parse(grpcError.details) as { httpStatus: number; errorCode: string };
+        expect(parsed.httpStatus).toBe(HttpStatus.NOT_ACCEPTABLE);
+        expect(parsed.errorCode).toBe(ErrorCodes.CLIENT_INPUT_ERROR);
+      }
+    });
+
+    it('should map 504 HttpException to DEADLINE_EXCEEDED', async () => {
+      const { host } = mockGrpcHost();
+      const result$ = filter.catch(new HttpException('gateway timeout', HttpStatus.GATEWAY_TIMEOUT), host);
+
+      try {
+        await firstValueFrom(result$);
+        expect.unreachable('expected HttpException to be thrown as gRPC error');
+      } catch (error: unknown) {
+        const grpcError = error as { code: number; details: string };
+        expect(grpcError.code).toBe(status.DEADLINE_EXCEEDED);
+        const parsed = JSON.parse(grpcError.details) as { httpStatus: number; errorCode: string };
+        expect(parsed.httpStatus).toBe(HttpStatus.GATEWAY_TIMEOUT);
+        expect(parsed.errorCode).toBe(ErrorCodes.SYSTEM_INTERNAL_ERROR);
       }
     });
   });

--- a/nest/src/exceptions/grpc-exception.filter.ts
+++ b/nest/src/exceptions/grpc-exception.filter.ts
@@ -1,9 +1,10 @@
-import { Catch } from '@nestjs/common';
+import { Catch, HttpException } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';
 
 import { getAppLogger } from '@app/utils/app-logger';
 
 import { OOPS_ERROR_METADATA_KEY } from './error-codes';
+import { toErrorDescriptor } from './error-descriptor';
 import { Oops } from './oops';
 import { OopsError } from './oops-error';
 
@@ -92,6 +93,10 @@ export class GrpcExceptionFilter implements ExceptionFilter {
 
     if (exception instanceof RpcException) {
       return this.handleRpcException(exception);
+    }
+
+    if (exception instanceof HttpException) {
+      return this.handleHttpException(exception, host);
     }
 
     // 其他未知错误
@@ -259,6 +264,37 @@ export class GrpcExceptionFilter implements ExceptionFilter {
     return throwError(() => ({ code: status.INVALID_ARGUMENT, details: JSON.stringify(grpcError) }));
   }
 
+  private handleHttpException(exception: HttpException, host: ArgumentsHost): Observable<never> {
+    const descriptor = toErrorDescriptor(exception);
+    if (!descriptor) {
+      return this.handleUnexpectedError(exception, host);
+    }
+
+    const grpcError: GrpcError = {
+      httpStatus: descriptor.httpStatus,
+      errorCode: descriptor.code,
+      businessCode: descriptor.code,
+      userMessage: descriptor.message,
+      provider: this.provider,
+    };
+
+    if (descriptor.errors !== undefined) {
+      grpcError.internalDetails = this.stringifyRpcExceptionDetails(descriptor.errors);
+    }
+
+    const grpcStatus = this.httpStatusToGrpcStatus(descriptor.httpStatus);
+    const details = JSON.stringify(grpcError);
+
+    if (descriptor.logLevel === 'error') {
+      this.logger.error`[HttpException] ${descriptor.httpStatus} ${descriptor.code} ${descriptor.message} ${exception}`;
+      this.captureFatalToSentry(exception, host);
+    } else {
+      this.logger.warning`[HttpException] ${descriptor.httpStatus} ${descriptor.code} ${descriptor.message}`;
+    }
+
+    return throwError(() => ({ code: grpcStatus, details }));
+  }
+
   private handleRpcException(exception: RpcException): Observable<never> {
     const serialized = this.serializeRpcException(exception);
 
@@ -327,6 +363,7 @@ export class GrpcExceptionFilter implements ExceptionFilter {
     // - 502/503 UNAVAILABLE: 上游依赖不可用，区别于本服务内部故障
     if (httpStatus === 502) return status.UNAVAILABLE;
     if (httpStatus === 503) return status.UNAVAILABLE;
+    if (httpStatus === 504) return status.DEADLINE_EXCEEDED;
     if (httpStatus >= 500) return status.INTERNAL;
     if (httpStatus === 400) return status.INVALID_ARGUMENT;
     if (httpStatus === 401) return status.UNAUTHENTICATED;
@@ -338,6 +375,7 @@ export class GrpcExceptionFilter implements ExceptionFilter {
     if (httpStatus === 415) return status.INVALID_ARGUMENT;
     if (httpStatus === 422) return status.FAILED_PRECONDITION;
     if (httpStatus === 429) return status.RESOURCE_EXHAUSTED;
+    if (httpStatus >= 400 && httpStatus < 500) return status.INVALID_ARGUMENT;
     return status.UNKNOWN;
   }
 }

--- a/nest/src/logging/configure.spec.ts
+++ b/nest/src/logging/configure.spec.ts
@@ -1,0 +1,90 @@
+import { prodFormatter, setActiveTraceIdResolver } from '@app/utils/log-formatter';
+
+import { registerActiveTraceIdResolver } from './configure';
+
+import { context, ROOT_CONTEXT, trace, TraceFlags } from '@opentelemetry/api';
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import type { LogRecord } from '@app/utils/log-formatter';
+import type { Context, ContextManager, Span } from '@opentelemetry/api';
+
+const TRACE_ID = '11111111111111111111111111111111';
+const SPAN_ID = '2222222222222222';
+
+class TestContextManager implements ContextManager {
+  private activeContext: Context = ROOT_CONTEXT;
+
+  active(): Context {
+    return this.activeContext;
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    contextValue: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    const previous = this.activeContext;
+    this.activeContext = contextValue;
+    try {
+      return fn.call(thisArg, ...args);
+    } finally {
+      this.activeContext = previous;
+    }
+  }
+
+  bind<T>(_contextValue: Context, target: T): T {
+    return target;
+  }
+
+  enable(): this {
+    return this;
+  }
+
+  disable(): this {
+    this.activeContext = ROOT_CONTEXT;
+    return this;
+  }
+}
+
+const contextManager = new TestContextManager();
+
+context.setGlobalContextManager(contextManager);
+
+afterEach(() => {
+  setActiveTraceIdResolver(undefined);
+});
+
+function makeRecord(): LogRecord {
+  return {
+    timestamp: 1_735_689_600_000,
+    level: 'info',
+    category: ['test'],
+    message: ['hello'],
+    rawMessage: 'hello',
+    properties: {},
+  };
+}
+
+function makeSpan(traceId: string): Span {
+  return {
+    spanContext: () => ({
+      traceId,
+      spanId: SPAN_ID,
+      traceFlags: TraceFlags.SAMPLED,
+    }),
+  } as unknown as Span;
+}
+
+describe('registerActiveTraceIdResolver', () => {
+  it('wires LogTape formatter fallback to the active OpenTelemetry span', () => {
+    registerActiveTraceIdResolver();
+
+    const ctx = trace.setSpan(context.active(), makeSpan(TRACE_ID));
+    context.with(ctx, () => {
+      const output = JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>;
+
+      expect(output.traceId).toBe(TRACE_ID);
+    });
+  });
+});

--- a/nest/src/logging/configure.ts
+++ b/nest/src/logging/configure.ts
@@ -1,6 +1,7 @@
-import { devFormatter, prodFormatter } from '@app/utils/log-formatter';
+import { devFormatter, prodFormatter, setActiveTraceIdResolver } from '@app/utils/log-formatter';
 
 import { configure, getConsoleSink } from '@logtape/logtape';
+import { context, trace } from '@opentelemetry/api';
 
 import type { LogLevel as LogTapeLevel } from '@logtape/logtape';
 import type { LogLevel } from '@nestjs/common';
@@ -17,6 +18,10 @@ const nestToLogtapeLevel: Record<LogLevel, LogTapeLevel> = {
 
 let configured = false;
 
+export function registerActiveTraceIdResolver(): void {
+  setActiveTraceIdResolver(() => trace.getSpan(context.active())?.spanContext().traceId);
+}
+
 /**
  * Initialize LogTape logging.
  *
@@ -24,6 +29,8 @@ let configured = false;
  * Prod: shared prodFormatter (JSON lines for log aggregation)
  */
 export async function configureLogging(nestLevel?: LogLevel): Promise<void> {
+  registerActiveTraceIdResolver();
+
   if (configured) return;
   configured = true;
 

--- a/utils/src/log-formatter.spec.ts
+++ b/utils/src/log-formatter.spec.ts
@@ -1,0 +1,113 @@
+import { devFormatter, prodFormatter } from './log-formatter';
+
+import { context, trace, TraceFlags } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import type { LogRecord } from './log-formatter';
+
+const TRACE_ID = '11111111111111111111111111111111';
+const OTHER_TRACE_ID = '22222222222222222222222222222222';
+const EXPLICIT_TRACE_ID = '33333333333333333333333333333333';
+const INVALID_TRACE_ID = '00000000000000000000000000000000';
+const SPAN_ID = '4444444444444444';
+
+let provider: NodeTracerProvider;
+
+beforeAll(() => {
+  provider = new NodeTracerProvider();
+  provider.register();
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  trace.disable();
+});
+
+function makeRecord(properties: Record<string, unknown> = {}): LogRecord {
+  return {
+    timestamp: 1_735_689_600_000,
+    level: 'info',
+    category: ['test'],
+    message: ['hello'],
+    rawMessage: 'hello',
+    properties,
+  };
+}
+
+function withActiveTrace<T>(traceId: string, callback: () => T): T {
+  const span = trace.wrapSpanContext({
+    traceId,
+    spanId: SPAN_ID,
+    traceFlags: TraceFlags.SAMPLED,
+  });
+
+  return context.with(trace.setSpan(context.active(), span), callback);
+}
+
+function stripAnsi(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+describe('devFormatter trace context', () => {
+  it('does not add a trace tag without record or active span traceId', () => {
+    const output = stripAnsi(devFormatter(makeRecord()));
+
+    expect(output).not.toContain('[');
+  });
+
+  it('uses record traceId before active span traceId', () => {
+    const output = withActiveTrace(OTHER_TRACE_ID, () =>
+      stripAnsi(devFormatter(makeRecord({ traceId: EXPLICIT_TRACE_ID }))),
+    );
+
+    expect(output).toContain(`[${EXPLICIT_TRACE_ID}]`);
+    expect(output).not.toContain(OTHER_TRACE_ID);
+  });
+
+  it('falls back to active span traceId', () => {
+    const output = withActiveTrace(TRACE_ID, () => stripAnsi(devFormatter(makeRecord())));
+
+    expect(output).toContain(`[${TRACE_ID}]`);
+  });
+
+  it('does not inject an invalid active span traceId', () => {
+    const output = withActiveTrace(INVALID_TRACE_ID, () => stripAnsi(devFormatter(makeRecord())));
+
+    expect(output).not.toContain(INVALID_TRACE_ID);
+    expect(output).not.toContain('[');
+  });
+});
+
+describe('prodFormatter trace context', () => {
+  it('does not add traceId without record or active span traceId', () => {
+    const output = JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>;
+
+    expect(output.traceId).toBeUndefined();
+  });
+
+  it('uses record traceId before active span traceId', () => {
+    const output = withActiveTrace(
+      OTHER_TRACE_ID,
+      () => JSON.parse(prodFormatter(makeRecord({ traceId: EXPLICIT_TRACE_ID }))) as Record<string, unknown>,
+    );
+
+    expect(output.traceId).toBe(EXPLICIT_TRACE_ID);
+  });
+
+  it('falls back to active span traceId', () => {
+    const output = withActiveTrace(TRACE_ID, () => JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>);
+
+    expect(output.traceId).toBe(TRACE_ID);
+  });
+
+  it('does not inject an invalid active span traceId', () => {
+    const output = withActiveTrace(
+      INVALID_TRACE_ID,
+      () => JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>,
+    );
+
+    expect(output.traceId).toBeUndefined();
+  });
+});

--- a/utils/src/log-formatter.spec.ts
+++ b/utils/src/log-formatter.spec.ts
@@ -1,8 +1,9 @@
-import { devFormatter, prodFormatter } from './log-formatter';
+import { devFormatter, prodFormatter, setActiveTraceIdResolver } from './log-formatter';
 
-import { context, trace, TraceFlags } from '@opentelemetry/api';
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'bun:test';
 
 import type { LogRecord } from './log-formatter';
 
@@ -10,18 +11,9 @@ const TRACE_ID = '11111111111111111111111111111111';
 const OTHER_TRACE_ID = '22222222222222222222222222222222';
 const EXPLICIT_TRACE_ID = '33333333333333333333333333333333';
 const INVALID_TRACE_ID = '00000000000000000000000000000000';
-const SPAN_ID = '4444444444444444';
 
-let provider: NodeTracerProvider;
-
-beforeAll(() => {
-  provider = new NodeTracerProvider();
-  provider.register();
-});
-
-afterAll(async () => {
-  await provider.shutdown();
-  trace.disable();
+afterEach(() => {
+  setActiveTraceIdResolver(undefined);
 });
 
 function makeRecord(properties: Record<string, unknown> = {}): LogRecord {
@@ -35,22 +27,18 @@ function makeRecord(properties: Record<string, unknown> = {}): LogRecord {
   };
 }
 
-function withActiveTrace<T>(traceId: string, callback: () => T): T {
-  const span = trace.wrapSpanContext({
-    traceId,
-    spanId: SPAN_ID,
-    traceFlags: TraceFlags.SAMPLED,
-  });
-
-  return context.with(trace.setSpan(context.active(), span), callback);
-}
-
 function stripAnsi(value: string): string {
   // eslint-disable-next-line no-control-regex
   return value.replace(/\x1b\[[0-9;]*m/g, '');
 }
 
 describe('devFormatter trace context', () => {
+  it('does not import optional OpenTelemetry from the shared formatter', () => {
+    const source = readFileSync(join(import.meta.dir, 'log-formatter.ts'), 'utf8');
+
+    expect(source).not.toContain('@opentelemetry/api');
+  });
+
   it('does not add a trace tag without record or active span traceId', () => {
     const output = stripAnsi(devFormatter(makeRecord()));
 
@@ -58,22 +46,23 @@ describe('devFormatter trace context', () => {
   });
 
   it('uses record traceId before active span traceId', () => {
-    const output = withActiveTrace(OTHER_TRACE_ID, () =>
-      stripAnsi(devFormatter(makeRecord({ traceId: EXPLICIT_TRACE_ID }))),
-    );
+    setActiveTraceIdResolver(() => OTHER_TRACE_ID);
+    const output = stripAnsi(devFormatter(makeRecord({ traceId: EXPLICIT_TRACE_ID })));
 
     expect(output).toContain(`[${EXPLICIT_TRACE_ID}]`);
     expect(output).not.toContain(OTHER_TRACE_ID);
   });
 
-  it('falls back to active span traceId', () => {
-    const output = withActiveTrace(TRACE_ID, () => stripAnsi(devFormatter(makeRecord())));
+  it('falls back to the injected active traceId resolver', () => {
+    setActiveTraceIdResolver(() => TRACE_ID);
+    const output = stripAnsi(devFormatter(makeRecord()));
 
     expect(output).toContain(`[${TRACE_ID}]`);
   });
 
-  it('does not inject an invalid active span traceId', () => {
-    const output = withActiveTrace(INVALID_TRACE_ID, () => stripAnsi(devFormatter(makeRecord())));
+  it('does not inject an invalid active traceId', () => {
+    setActiveTraceIdResolver(() => INVALID_TRACE_ID);
+    const output = stripAnsi(devFormatter(makeRecord()));
 
     expect(output).not.toContain(INVALID_TRACE_ID);
     expect(output).not.toContain('[');
@@ -88,25 +77,22 @@ describe('prodFormatter trace context', () => {
   });
 
   it('uses record traceId before active span traceId', () => {
-    const output = withActiveTrace(
-      OTHER_TRACE_ID,
-      () => JSON.parse(prodFormatter(makeRecord({ traceId: EXPLICIT_TRACE_ID }))) as Record<string, unknown>,
-    );
+    setActiveTraceIdResolver(() => OTHER_TRACE_ID);
+    const output = JSON.parse(prodFormatter(makeRecord({ traceId: EXPLICIT_TRACE_ID }))) as Record<string, unknown>;
 
     expect(output.traceId).toBe(EXPLICIT_TRACE_ID);
   });
 
-  it('falls back to active span traceId', () => {
-    const output = withActiveTrace(TRACE_ID, () => JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>);
+  it('falls back to the injected active traceId resolver', () => {
+    setActiveTraceIdResolver(() => TRACE_ID);
+    const output = JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>;
 
     expect(output.traceId).toBe(TRACE_ID);
   });
 
-  it('does not inject an invalid active span traceId', () => {
-    const output = withActiveTrace(
-      INVALID_TRACE_ID,
-      () => JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>,
-    );
+  it('does not inject an invalid active traceId', () => {
+    setActiveTraceIdResolver(() => INVALID_TRACE_ID);
+    const output = JSON.parse(prodFormatter(makeRecord())) as Record<string, unknown>;
 
     expect(output.traceId).toBeUndefined();
   });

--- a/utils/src/log-formatter.ts
+++ b/utils/src/log-formatter.ts
@@ -10,6 +10,7 @@
 import { r } from './logging';
 
 import { Temporal } from '@js-temporal/polyfill';
+import { trace } from '@opentelemetry/api';
 
 // ==================== ANSI Colors ====================
 
@@ -48,6 +49,13 @@ function colorLevel(level: string): string {
   return `${ansi.bold}${color}${upper}${ansi.reset}`;
 }
 
+const INVALID_TRACE_ID = '00000000000000000000000000000000';
+
+function activeTraceId(): string | undefined {
+  const traceId = trace.getActiveSpan()?.spanContext().traceId;
+  return traceId && traceId !== INVALID_TRACE_ID ? traceId : undefined;
+}
+
 // ==================== LogTape Record Type ====================
 
 export interface LogRecord {
@@ -74,8 +82,9 @@ export function devFormatter(record: LogRecord): string {
   // Context tag: [spanName|traceId|userId|...contextTags]
   const contextParts: string[] = [];
   const { traceId, userId, spanName, contextTags } = record.properties;
+  const effectiveTraceId = typeof traceId === 'string' && traceId.length > 0 ? traceId : activeTraceId();
   if (spanName && typeof spanName === 'string') contextParts.push(spanName);
-  if (traceId && typeof traceId === 'string') contextParts.push(traceId);
+  if (effectiveTraceId) contextParts.push(effectiveTraceId);
   if (userId && typeof userId === 'string' && userId.trim().length > 0) contextParts.push(userId);
   // Extra context tags (from NestJS RequestContext non-standard fields)
   if (Array.isArray(contextTags)) {
@@ -153,6 +162,11 @@ export function prodFormatter(record: LogRecord): string {
   // Flatten properties (module, traceId, userId, spanName)
   for (const [k, v] of Object.entries(record.properties)) {
     if (v !== undefined && v !== null) entry[k] = v;
+  }
+
+  if (!entry.traceId) {
+    const traceId = activeTraceId();
+    if (traceId) entry.traceId = traceId;
   }
 
   return JSON.stringify(entry);

--- a/utils/src/log-formatter.ts
+++ b/utils/src/log-formatter.ts
@@ -53,6 +53,7 @@ type ActiveTraceIdResolver = () => string | undefined;
 
 let activeTraceIdResolver: ActiveTraceIdResolver | undefined;
 
+// Runtime integrations that already require OTel install this; shared utils stays peer-free.
 export function setActiveTraceIdResolver(resolver: ActiveTraceIdResolver | undefined): void {
   activeTraceIdResolver = resolver;
 }

--- a/utils/src/log-formatter.ts
+++ b/utils/src/log-formatter.ts
@@ -10,7 +10,6 @@
 import { r } from './logging';
 
 import { Temporal } from '@js-temporal/polyfill';
-import { trace } from '@opentelemetry/api';
 
 // ==================== ANSI Colors ====================
 
@@ -50,9 +49,16 @@ function colorLevel(level: string): string {
 }
 
 const INVALID_TRACE_ID = '00000000000000000000000000000000';
+type ActiveTraceIdResolver = () => string | undefined;
+
+let activeTraceIdResolver: ActiveTraceIdResolver | undefined;
+
+export function setActiveTraceIdResolver(resolver: ActiveTraceIdResolver | undefined): void {
+  activeTraceIdResolver = resolver;
+}
 
 function activeTraceId(): string | undefined {
-  const traceId = trace.getActiveSpan()?.spanContext().traceId;
+  const traceId = activeTraceIdResolver?.();
   return traceId && traceId !== INVALID_TRACE_ID ? traceId : undefined;
 }
 


### PR DESCRIPTION
## Summary
- add gRPC HttpException boundary mapping through a shared error descriptor normalizer
- add active OTel span traceId fallback to shared log formatters
- register Vertex direct gemini-3.5-flash model keys for regional and global providers

## Why
These are the framework-level gaps from the Shawn comparison that belong in nestjs-libs. Business-specific sandbox provenance is intentionally left out for a separate contract design.

## Validation
- bun test nest/src/exceptions/grpc-exception.filter.spec.ts nest/src/exceptions/any-exception.filter.spec.ts utils/src/log-formatter.spec.ts features/llm/types/model.types.spec.ts
- bun run typecheck
- bunx prettier --check targeted files
- bunx eslint targeted files --no-warn-ignored
- pre-push hook: tsc --noEmit, eslint . --fix, bun test (466 pass)