### PR TITLE
Add request provenance tags

### DIFF
--- a/features/llm/clients/auto.client.ts
+++ b/features/llm/clients/auto.client.ts
@@ -25,6 +25,7 @@
  */
 import { SysEnv } from '@app/env';
 import { Oops } from '@app/nest/exceptions/oops';
+import { mergeProvenanceLlmTags } from '@app/nest/trace/provenance-tags';
 
 import { getModel } from '../types/model.types';
 import { google, openrouter, vertex, vertexGlobal } from './llm.clients';
@@ -411,7 +412,8 @@ class LLMBuilder {
     const context: BuilderTelemetryContext = {};
     if (this._telemetry?.userId) context.userId = this._telemetry.userId;
     if (this._telemetry?.sessionId) context.sessionId = this._telemetry.sessionId;
-    if (this._telemetry?.tags?.length) context.tags = this._telemetry.tags;
+    const tags = mergeProvenanceLlmTags(this._telemetry?.tags);
+    if (tags.length) context.tags = tags;
     if (this._telemetry?.parentObservationId) context.parentObservationId = this._telemetry.parentObservationId;
 
     return Object.keys(context).length > 0 ? context : undefined;

--- a/features/llm/clients/auto.client.ts
+++ b/features/llm/clients/auto.client.ts
@@ -25,7 +25,7 @@
  */
 import { SysEnv } from '@app/env';
 import { Oops } from '@app/nest/exceptions/oops';
-import { mergeProvenanceLlmTags } from '@app/nest/trace/provenance-tags';
+import { mergeProvenanceLlmTags } from '@app/nest/trace/provenance-context';
 
 import { getModel } from '../types/model.types';
 import { google, openrouter, vertex, vertexGlobal } from './llm.clients';

--- a/features/llm/clients/llm.class.ts
+++ b/features/llm/clients/llm.class.ts
@@ -29,7 +29,7 @@
 
 import { SysEnv } from '@app/env';
 import { Oops } from '@app/nest/exceptions/oops';
-import { mergeProvenanceLlmTags } from '@app/nest/trace/provenance-tags';
+import { mergeProvenanceLlmTags } from '@app/nest/trace/provenance-context';
 import { RequestContext } from '@app/nest/trace/request-context';
 import { getAppLogger } from '@app/utils/app-logger';
 import { ApiFetcher } from '@app/utils/fetch';

--- a/features/llm/clients/llm.class.ts
+++ b/features/llm/clients/llm.class.ts
@@ -29,6 +29,7 @@
 
 import { SysEnv } from '@app/env';
 import { Oops } from '@app/nest/exceptions/oops';
+import { mergeProvenanceLlmTags } from '@app/nest/trace/provenance-tags';
 import { RequestContext } from '@app/nest/trace/request-context';
 import { getAppLogger } from '@app/utils/app-logger';
 import { ApiFetcher } from '@app/utils/fetch';
@@ -99,7 +100,10 @@ type ProviderOptionsSurface = {
 // ═══════════════════════════════════════════════════════════════════════════
 
 /** 默认开启 telemetry，OTel exporter 未配置时无副作用 */
-const DEFAULT_TELEMETRY: TelemetryOptions = { isEnabled: true };
+const DEFAULT_TELEMETRY: TelemetryOptions = {
+  isEnabled: true,
+  includeRuntimeContext: { tags: true },
+};
 
 /** 仅这些模型启用 JSON 代码块剥离中间件 */
 const MODELS_NEEDING_EXTRACT_JSON = new Set<LLMModelKey>(['openrouter:kimi-k2.5', 'openrouter:moonshotai/kimi-k2.5']);
@@ -446,6 +450,43 @@ function createLanguageModelForCall(
   });
 }
 
+function getRuntimeContextTags(runtimeContext: Context | undefined): string[] {
+  const tags = runtimeContext?.tags;
+  return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string') : [];
+}
+
+export function mergeProvenanceRuntimeContext<RUNTIME_CONTEXT extends Context>(
+  runtimeContext?: RUNTIME_CONTEXT,
+): RUNTIME_CONTEXT | undefined {
+  const tags = mergeProvenanceLlmTags(getRuntimeContextTags(runtimeContext));
+  if (tags.length === 0) return runtimeContext;
+
+  if (runtimeContext !== undefined) {
+    return {
+      ...runtimeContext,
+      tags,
+    };
+  }
+
+  return { tags } as unknown as RUNTIME_CONTEXT;
+}
+
+function withProvenanceTelemetry<RUNTIME_CONTEXT extends Context, TOOLS extends ToolSet>(
+  telemetry: TelemetryOptions<RUNTIME_CONTEXT, TOOLS>,
+): TelemetryOptions<RUNTIME_CONTEXT, TOOLS> {
+  if (telemetry.isEnabled === false) {
+    return telemetry;
+  }
+
+  return {
+    ...telemetry,
+    includeRuntimeContext: {
+      ...telemetry.includeRuntimeContext,
+      tags: true,
+    },
+  };
+}
+
 interface ResolveAIOptionsContext {
   id: string;
   method: string;
@@ -477,6 +518,10 @@ function wrapPrepareStep<TOOLS extends ToolSet, RUNTIME_CONTEXT extends Context>
     }
 
     const { model: _model, providerOptions: _providerOptions, llm, ...safe } = unsafe;
+    if (safe.runtimeContext !== undefined) {
+      safe.runtimeContext = mergeProvenanceRuntimeContext(safe.runtimeContext as RUNTIME_CONTEXT);
+    }
+
     if (!llm) {
       return safe;
     }
@@ -1057,7 +1102,8 @@ export class LLM {
           maxOutputTokens,
           maxRetries: spec.maxRetries,
           abortSignal: signal,
-          telemetry,
+          telemetry: withProvenanceTelemetry(telemetry),
+          runtimeContext: mergeProvenanceRuntimeContext(),
         });
 
         cleanup();
@@ -1266,6 +1312,7 @@ export class LLM {
       const headers = mergeHeaders(aiOptions?.headers, tierHeaders);
 
       const { signal, cleanup } = createManagedSignal(spec.timeout, abortSignal ?? aiOptions?.abortSignal);
+      const runtimeContext = mergeProvenanceRuntimeContext<RUNTIME_CONTEXT>(aiOptions?.runtimeContext);
 
       try {
         const result = await generateText({
@@ -1280,7 +1327,8 @@ export class LLM {
           ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
           maxRetries: spec.maxRetries,
           abortSignal: signal,
-          telemetry,
+          telemetry: withProvenanceTelemetry(telemetry),
+          ...(runtimeContext !== undefined ? { runtimeContext } : {}),
         });
 
         cleanup();
@@ -1399,7 +1447,8 @@ export class LLM {
       ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
       maxRetries: spec.maxRetries,
       abortSignal: signal,
-      telemetry,
+      telemetry: withProvenanceTelemetry(telemetry),
+      runtimeContext: mergeProvenanceRuntimeContext(aiOptions?.runtimeContext),
       onError: async (event: StreamOnErrorEvent) => {
         await aiOptions?.onError?.(event);
         cleanup();
@@ -1500,7 +1549,8 @@ export class LLM {
       ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
       maxRetries: spec.maxRetries,
       abortSignal: signal,
-      telemetry,
+      telemetry: withProvenanceTelemetry(telemetry),
+      runtimeContext: mergeProvenanceRuntimeContext(aiOptions?.runtimeContext),
       onError: async (event: StreamOnErrorEvent) => {
         await aiOptions?.onError?.(event);
         cleanup();
@@ -1632,7 +1682,8 @@ export class LLM {
           maxOutputTokens,
           maxRetries: spec.maxRetries,
           abortSignal: signal,
-          telemetry,
+          telemetry: withProvenanceTelemetry(telemetry),
+          runtimeContext: mergeProvenanceRuntimeContext(),
         });
 
         cleanup();
@@ -1799,7 +1850,8 @@ export class LLM {
       maxOutputTokens,
       maxRetries: spec.maxRetries,
       abortSignal: signal,
-      telemetry,
+      telemetry: withProvenanceTelemetry(telemetry),
+      runtimeContext: mergeProvenanceRuntimeContext(),
       onError: ({ error }) => {
         cleanup();
         LLM.logError(id, 'streamObjectViaTool', modelKey, error);

--- a/features/llm/clients/provenance-runtime-context.spec.ts
+++ b/features/llm/clients/provenance-runtime-context.spec.ts
@@ -8,6 +8,9 @@ import { llm } from './auto.client';
 import { mergeProvenanceRuntimeContext } from './llm.class';
 import { resetLLMClients } from './llm.clients';
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 interface LLMBuilderTestAccess {
@@ -88,5 +91,19 @@ describe('LLM provenance runtime context', () => {
         tags: ['task:reply', 'origin.channel:api', 'sandbox.client_type:browser'],
       });
     });
+  });
+
+  it('keeps LLM client provenance formatting independent from tracing span helpers', () => {
+    const autoClient = readFileSync(join(import.meta.dir, 'auto.client.ts'), 'utf8');
+    const llmClass = readFileSync(join(import.meta.dir, 'llm.class.ts'), 'utf8');
+    const provenanceContext = readFileSync(join(process.cwd(), 'nest/src/trace/provenance-context.ts'), 'utf8');
+    const provenanceFormat = readFileSync(join(process.cwd(), 'nest/src/trace/provenance-format.ts'), 'utf8');
+
+    expect(autoClient).not.toContain('@app/nest/trace/provenance-tags');
+    expect(llmClass).not.toContain('@app/nest/trace/provenance-tags');
+    expect(autoClient).toContain('@app/nest/trace/provenance-context');
+    expect(llmClass).toContain('@app/nest/trace/provenance-context');
+    expect(provenanceContext).not.toContain('@opentelemetry/api');
+    expect(provenanceFormat).not.toContain('@opentelemetry/api');
   });
 });

--- a/features/llm/clients/provenance-runtime-context.spec.ts
+++ b/features/llm/clients/provenance-runtime-context.spec.ts
@@ -1,0 +1,92 @@
+import 'reflect-metadata';
+
+import { SysEnv } from '@app/env';
+import { setProvenanceTags } from '@app/nest/trace/provenance-tags';
+import { RequestContext } from '@app/nest/trace/request-context';
+
+import { llm } from './auto.client';
+import { mergeProvenanceRuntimeContext } from './llm.class';
+import { resetLLMClients } from './llm.clients';
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+interface LLMBuilderTestAccess {
+  _buildTelemetryRuntimeContext(): unknown;
+}
+
+const sysEnvMut = SysEnv as unknown as Record<string, string | undefined>;
+const originalSysEnv = {
+  GOOGLE_VERTEX_PROJECT: sysEnvMut.GOOGLE_VERTEX_PROJECT,
+  GOOGLE_VERTEX_LOCATION: sysEnvMut.GOOGLE_VERTEX_LOCATION,
+  GOOGLE_CLOUD_PROJECT: sysEnvMut.GOOGLE_CLOUD_PROJECT,
+  GOOGLE_CLOUD_LOCATION: sysEnvMut.GOOGLE_CLOUD_LOCATION,
+};
+const originalProcessGoogleVertexApiKey = process.env.GOOGLE_VERTEX_API_KEY;
+
+beforeEach(() => {
+  sysEnvMut.GOOGLE_VERTEX_PROJECT = 'test-project';
+  sysEnvMut.GOOGLE_VERTEX_LOCATION = 'global';
+  delete sysEnvMut.GOOGLE_CLOUD_PROJECT;
+  delete sysEnvMut.GOOGLE_CLOUD_LOCATION;
+  process.env.GOOGLE_VERTEX_API_KEY = 'test-express-mode-key';
+  resetLLMClients();
+});
+
+afterEach(() => {
+  sysEnvMut.GOOGLE_VERTEX_PROJECT = originalSysEnv.GOOGLE_VERTEX_PROJECT;
+  sysEnvMut.GOOGLE_VERTEX_LOCATION = originalSysEnv.GOOGLE_VERTEX_LOCATION;
+  sysEnvMut.GOOGLE_CLOUD_PROJECT = originalSysEnv.GOOGLE_CLOUD_PROJECT;
+  sysEnvMut.GOOGLE_CLOUD_LOCATION = originalSysEnv.GOOGLE_CLOUD_LOCATION;
+  if (originalProcessGoogleVertexApiKey === undefined) {
+    delete process.env.GOOGLE_VERTEX_API_KEY;
+  } else {
+    process.env.GOOGLE_VERTEX_API_KEY = originalProcessGoogleVertexApiKey;
+  }
+  resetLLMClients();
+});
+
+describe('LLM provenance runtime context', () => {
+  it('appends request provenance after caller runtime tags', () => {
+    RequestContext.run({}, () => {
+      setProvenanceTags({
+        'sandbox.client_type': 'browser',
+        'sandbox.token': 'drop',
+      });
+
+      expect(
+        mergeProvenanceRuntimeContext({
+          parentObservationId: 'parent-1',
+          tags: ['task:reply'],
+        }),
+      ).toEqual({
+        parentObservationId: 'parent-1',
+        tags: ['task:reply', 'sandbox.client_type:browser'],
+      });
+    });
+  });
+
+  it('does not create runtime context outside RequestContext when caller context has no tags', () => {
+    const callerContext = { parentObservationId: 'parent-1' };
+
+    expect(mergeProvenanceRuntimeContext(callerContext)).toBe(callerContext);
+  });
+
+  it('adds provenance tags to the deprecated builder telemetry runtime context', () => {
+    RequestContext.run({}, () => {
+      setProvenanceTags({
+        'origin.channel': 'api',
+        'sandbox.client_type': 'browser',
+      });
+
+      const builder = llm('vertex-global:gemini-2.5-flash').telemetry({
+        userId: 'user-1',
+        tags: ['task:reply'],
+      }) as unknown as LLMBuilderTestAccess;
+
+      expect(builder._buildTelemetryRuntimeContext()).toEqual({
+        userId: 'user-1',
+        tags: ['task:reply', 'origin.channel:api', 'sandbox.client_type:browser'],
+      });
+    });
+  });
+});

--- a/nest/src/logging/nest-logger.ts
+++ b/nest/src/logging/nest-logger.ts
@@ -1,12 +1,12 @@
-import { getAppLogger } from '@app/utils/app-logger';
+import { toProvenanceLogTags } from '@app/nest/trace/provenance-tags';
 import { RequestContext } from '@app/nest/trace/request-context';
+import { getAppLogger } from '@app/utils/app-logger';
 import { onelineStack } from '@app/utils/error';
 
 import { lazy } from '@logtape/logtape';
-
-import type { Logger } from '@logtape/logtape';
 import { context, trace } from '@opentelemetry/api';
 
+import type { Logger } from '@logtape/logtape';
 import type { LoggerService } from '@nestjs/common';
 
 /**
@@ -51,13 +51,14 @@ export class LogtapeNestLogger implements LoggerService {
     contextTags: lazy(() => {
       const entries = RequestContext.entries();
       if (!entries) return undefined;
-      const KNOWN_KEYS = new Set(['traceId', 'userId', 'spanName']);
+      const KNOWN_KEYS = new Set(['traceId', 'userId', 'spanName', 'provenance.tags']);
       const tags: string[] = [];
       for (const [key, value] of Object.entries(entries)) {
         if (!KNOWN_KEYS.has(key) && typeof value === 'string' && value.length > 0) {
           tags.push(value);
         }
       }
+      tags.push(...toProvenanceLogTags());
       return tags.length > 0 ? tags : undefined;
     }),
   });
@@ -95,7 +96,6 @@ export class LogtapeNestLogger implements LoggerService {
     const [msg, logger] = this.extractContext(message, optionalParams);
     logger.fatal`${msg}`;
   }
-   
 
   /**
    * Extract trailing context string (NestJS convention: last arg is the class/module name).

--- a/nest/src/trace/index.ts
+++ b/nest/src/trace/index.ts
@@ -1,4 +1,5 @@
 export * from './interface';
+export * from './provenance-tags';
 export * from './request-context';
 export * from './trace.decorator';
 export * from './langfuse';

--- a/nest/src/trace/provenance-context.ts
+++ b/nest/src/trace/provenance-context.ts
@@ -1,0 +1,58 @@
+import {
+  mergeProvenanceLlmTags as mergeProvenanceLlmTagsFromTags,
+  sanitizeProvenanceTags,
+  toProvenanceLlmTags as toProvenanceLlmTagsFromTags,
+  toProvenanceLogTags as toProvenanceLogTagsFromTags,
+} from './provenance-format';
+import { RequestContext } from './request-context';
+
+import type { ProvenanceTags } from './provenance-format';
+
+const PROVENANCE_TAGS_KEY = 'provenance.tags';
+
+function hasRequestContext(): boolean {
+  return RequestContext.entries() !== undefined;
+}
+
+export function setProvenanceTags(tags: Record<string, unknown>): void {
+  if (!hasRequestContext()) return;
+
+  const sanitized = sanitizeProvenanceTags(tags, { warn: true });
+  RequestContext.set(PROVENANCE_TAGS_KEY, sanitized);
+}
+
+export function mergeProvenanceTags(tags: Record<string, unknown>): void {
+  if (!hasRequestContext()) return;
+
+  const merged = {
+    ...getProvenanceTags(),
+    ...sanitizeProvenanceTags(tags, { warn: true }),
+  };
+  const sanitized = sanitizeProvenanceTags(merged);
+  RequestContext.set(PROVENANCE_TAGS_KEY, sanitized);
+}
+
+export function getProvenanceTags(): ProvenanceTags {
+  const current = RequestContext.get<Record<string, unknown>>(PROVENANCE_TAGS_KEY);
+  return sanitizeProvenanceTags(current);
+}
+
+export function clearProvenanceTags(): void {
+  if (!hasRequestContext()) return;
+  RequestContext.set(PROVENANCE_TAGS_KEY, undefined);
+}
+
+export function toProvenanceLogTags(tags: ProvenanceTags = getProvenanceTags()): string[] {
+  return toProvenanceLogTagsFromTags(tags);
+}
+
+export function toProvenanceLlmTags(tags: ProvenanceTags = getProvenanceTags()): string[] {
+  return toProvenanceLlmTagsFromTags(tags);
+}
+
+export function mergeProvenanceLlmTags(
+  existingTags: readonly string[] = [],
+  tags: ProvenanceTags = getProvenanceTags(),
+): string[] {
+  return mergeProvenanceLlmTagsFromTags(existingTags, tags);
+}

--- a/nest/src/trace/provenance-format.ts
+++ b/nest/src/trace/provenance-format.ts
@@ -1,0 +1,103 @@
+import { getAppLogger } from '@app/utils/app-logger';
+
+export type ProvenanceTags = Readonly<Record<string, string>>;
+
+const logger = getAppLogger('ProvenanceTags');
+
+const MAX_TAGS = 16;
+const MAX_KEY_LENGTH = 64;
+const MAX_VALUE_LENGTH = 256;
+const KEY_PATTERN = /^[a-z0-9_]+(\.[a-z0-9_]+)+$/;
+const SENSITIVE_KEY_PARTS = new Set([
+  'authorization',
+  'cookie',
+  'csrf_token',
+  'id_token',
+  'api_key',
+  'password',
+  'refresh_token',
+  'secret',
+  'token',
+]);
+
+function isSensitiveKey(key: string): boolean {
+  return key.split('.').some((part) => SENSITIVE_KEY_PARTS.has(part) || part.endsWith('_token'));
+}
+
+function normalizeValue(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function warnDropped(dropped: number): void {
+  if (dropped > 0) {
+    logger.warning`Dropped ${dropped} invalid provenance tag(s)`;
+  }
+}
+
+export function sanitizeProvenanceTags(
+  input: Record<string, unknown> | undefined,
+  options?: { warn?: boolean },
+): ProvenanceTags {
+  if (!input) return Object.freeze({});
+
+  const output: Record<string, string> = {};
+  let accepted = 0;
+  let dropped = 0;
+
+  for (const [key, rawValue] of Object.entries(input)) {
+    const value = normalizeValue(rawValue);
+    const valid =
+      key.length <= MAX_KEY_LENGTH &&
+      KEY_PATTERN.test(key) &&
+      !isSensitiveKey(key) &&
+      value !== undefined &&
+      value.length <= MAX_VALUE_LENGTH &&
+      accepted < MAX_TAGS;
+
+    if (!valid) {
+      dropped += 1;
+      continue;
+    }
+
+    output[key] = value;
+    accepted += 1;
+  }
+
+  if (options?.warn) {
+    warnDropped(dropped);
+  }
+  return Object.freeze(output);
+}
+
+export function sortedProvenanceEntries(tags: ProvenanceTags | undefined): Array<[string, string]> {
+  return Object.entries(sanitizeProvenanceTags(tags)).sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function toProvenanceLogTags(tags: ProvenanceTags | undefined = {}): string[] {
+  return sortedProvenanceEntries(tags).map(([key, value]) => `provenance:${key}=${value}`);
+}
+
+export function toProvenanceLlmTags(tags: ProvenanceTags | undefined = {}): string[] {
+  return sortedProvenanceEntries(tags).map(([key, value]) => `${key}:${value}`);
+}
+
+export function mergeProvenanceLlmTags(
+  existingTags: readonly string[] = [],
+  tags: ProvenanceTags | undefined = {},
+): string[] {
+  const provenanceTags = toProvenanceLlmTags(tags);
+  return provenanceTags.length > 0 ? [...existingTags, ...provenanceTags] : [...existingTags];
+}

--- a/nest/src/trace/provenance-tags.spec.ts
+++ b/nest/src/trace/provenance-tags.spec.ts
@@ -1,0 +1,178 @@
+import {
+  applyProvenanceToActiveSpan,
+  applyProvenanceToSpan,
+  clearProvenanceTags,
+  getProvenanceTags,
+  mergeProvenanceLlmTags,
+  mergeProvenanceTags,
+  sanitizeProvenanceTags,
+  setProvenanceTags,
+  toProvenanceLlmTags,
+  toProvenanceLogTags,
+} from './provenance-tags';
+import { RequestContext } from './request-context';
+
+import { describe, expect, it } from 'bun:test';
+
+import type { Span } from '@opentelemetry/api';
+
+function captureSpan() {
+  const attributes: Record<string, unknown> = {};
+  const span = {
+    setAttribute: (key: string, value: unknown) => {
+      attributes[key] = value;
+      return span;
+    },
+  } as unknown as Span;
+
+  return { span, attributes };
+}
+
+describe('provenance tag sanitization', () => {
+  it('accepts valid namespaced scalar tags and sorts keys deterministically', () => {
+    const input = {
+      'origin.channel': ' api ',
+      'sandbox.run_id': 123,
+      'sandbox.enabled': true,
+    };
+
+    expect(sanitizeProvenanceTags(input)).toEqual({
+      'origin.channel': 'api',
+      'sandbox.enabled': 'true',
+      'sandbox.run_id': '123',
+    });
+    expect(input['origin.channel']).toBe(' api ');
+  });
+
+  it('drops invalid keys, empty values, objects, arrays, and sensitive keys', () => {
+    expect(
+      sanitizeProvenanceTags({
+        sandbox: 'missing namespace',
+        'Sandbox.client_type': 'uppercase',
+        'sandbox.client-type': 'illegal char',
+        'sandbox.empty': '   ',
+        'sandbox.object': { raw: true },
+        'sandbox.array': ['raw'],
+        'sandbox.token': 'secret-token',
+        'sandbox.access_token': 'access-token',
+        'sandbox.refresh_token': 'refresh-token',
+        'sandbox.csrf_token': 'csrf-token',
+        'sandbox.cookie': 'session=raw',
+        'sandbox.client_type': 'browser',
+      }),
+    ).toEqual({
+      'sandbox.client_type': 'browser',
+    });
+  });
+
+  it('enforces key length, value length, and max tag count', () => {
+    const tooLongKey = `sandbox.${'x'.repeat(80)}`;
+    const input: Record<string, unknown> = {
+      [tooLongKey]: 'drop',
+      'sandbox.too_long': 'x'.repeat(257),
+    };
+
+    for (let i = 0; i < 20; i += 1) {
+      input[`k${i}.v`] = i;
+    }
+
+    const result = sanitizeProvenanceTags(input);
+
+    expect(result[tooLongKey]).toBeUndefined();
+    expect(result['sandbox.too_long']).toBeUndefined();
+    expect(Object.keys(result)).toHaveLength(16);
+    expect(result['k0.v']).toBe('0');
+    expect(result['k15.v']).toBe('15');
+    expect(result['k16.v']).toBeUndefined();
+  });
+});
+
+describe('RequestContext provenance tags', () => {
+  it('stores, merges, and clears sanitized tags inside RequestContext', () => {
+    RequestContext.run({}, () => {
+      setProvenanceTags({
+        'sandbox.client_type': 'browser',
+        'sandbox.token': 'drop',
+      });
+
+      expect(getProvenanceTags()).toEqual({
+        'sandbox.client_type': 'browser',
+      });
+
+      mergeProvenanceTags({
+        'origin.channel': 'api',
+        'sandbox.client_type': 'worker',
+      });
+
+      expect(getProvenanceTags()).toEqual({
+        'origin.channel': 'api',
+        'sandbox.client_type': 'worker',
+      });
+
+      clearProvenanceTags();
+      expect(getProvenanceTags()).toEqual({});
+    });
+  });
+
+  it('no-ops outside RequestContext', () => {
+    setProvenanceTags({ 'sandbox.client_type': 'browser' });
+    mergeProvenanceTags({ 'origin.channel': 'api' });
+    clearProvenanceTags();
+
+    expect(getProvenanceTags()).toEqual({});
+  });
+});
+
+describe('provenance projections', () => {
+  it('creates log tags and LLM tags with stable formatting', () => {
+    const tags = {
+      'origin.channel': 'api',
+      'sandbox.client_type': 'browser',
+    };
+
+    expect(toProvenanceLogTags(tags)).toEqual([
+      'provenance:origin.channel=api',
+      'provenance:sandbox.client_type=browser',
+    ]);
+    expect(toProvenanceLlmTags(tags)).toEqual(['origin.channel:api', 'sandbox.client_type:browser']);
+  });
+
+  it('merges provenance LLM tags after caller tags without mutating caller tags', () => {
+    const callerTags = ['task:reply'];
+    const result = mergeProvenanceLlmTags(callerTags, {
+      'sandbox.client_type': 'browser',
+    });
+
+    expect(result).toEqual(['task:reply', 'sandbox.client_type:browser']);
+    expect(callerTags).toEqual(['task:reply']);
+  });
+
+  it('applies provenance to a span as attributes and AI telemetry tags', () => {
+    const { span, attributes } = captureSpan();
+
+    applyProvenanceToSpan(span, {
+      'sandbox.client_type': 'browser',
+    });
+
+    expect(attributes['provenance.sandbox.client_type']).toBe('browser');
+    expect(attributes['ai.telemetry.metadata.tags']).toEqual(['sandbox.client_type:browser']);
+  });
+
+  it('appends span AI telemetry tags after existing caller tags', () => {
+    const { span, attributes } = captureSpan();
+
+    applyProvenanceToSpan(
+      span,
+      {
+        'sandbox.client_type': 'browser',
+      },
+      ['task:reply'],
+    );
+
+    expect(attributes['ai.telemetry.metadata.tags']).toEqual(['task:reply', 'sandbox.client_type:browser']);
+  });
+
+  it('does not throw when no active span exists', () => {
+    expect(() => applyProvenanceToActiveSpan({ 'sandbox.client_type': 'browser' })).not.toThrow();
+  });
+});

--- a/nest/src/trace/provenance-tags.spec.ts
+++ b/nest/src/trace/provenance-tags.spec.ts
@@ -7,13 +7,14 @@ import {
   mergeProvenanceLlmTags,
   mergeProvenanceTags,
   sanitizeProvenanceTags,
-  setActiveSpanLlmTags,
   setProvenanceTags,
   toProvenanceLlmTags,
   toProvenanceLogTags,
+  withActiveSpanLlmTags,
 } from './provenance-tags';
 import { RequestContext } from './request-context';
 
+import { context } from '@opentelemetry/api';
 import { describe, expect, it } from 'bun:test';
 
 import type { Span } from '@opentelemetry/api';
@@ -178,14 +179,21 @@ describe('provenance projections', () => {
     expect(() => applyProvenanceToActiveSpan({ 'sandbox.client_type': 'browser' })).not.toThrow();
   });
 
-  it('tracks active span caller tags in RequestContext for later provenance updates', () => {
-    RequestContext.run({}, () => {
-      const previous = setActiveSpanLlmTags(['task:reply']);
+  it('scopes active span caller tags per OTel context', () => {
+    const base = context.active();
+    const taskContext = withActiveSpanLlmTags(base, ['task:reply']);
+    const reviewContext = withActiveSpanLlmTags(base, ['task:review']);
 
-      expect(previous).toBeUndefined();
-      expect(getActiveSpanLlmTags()).toEqual(['task:reply']);
-      expect(setActiveSpanLlmTags(undefined)).toEqual(['task:reply']);
-      expect(getActiveSpanLlmTags()).toEqual([]);
-    });
+    expect(getActiveSpanLlmTags(taskContext)).toEqual(['task:reply']);
+    expect(getActiveSpanLlmTags(reviewContext)).toEqual(['task:review']);
+    expect(getActiveSpanLlmTags(base)).toEqual([]);
+  });
+
+  it('does not inherit caller tags when a child OTel context has no span tags', () => {
+    const parentContext = withActiveSpanLlmTags(context.active(), ['task:reply']);
+    const childContext = withActiveSpanLlmTags(parentContext, undefined);
+
+    expect(getActiveSpanLlmTags(parentContext)).toEqual(['task:reply']);
+    expect(getActiveSpanLlmTags(childContext)).toEqual([]);
   });
 });

--- a/nest/src/trace/provenance-tags.spec.ts
+++ b/nest/src/trace/provenance-tags.spec.ts
@@ -2,10 +2,12 @@ import {
   applyProvenanceToActiveSpan,
   applyProvenanceToSpan,
   clearProvenanceTags,
+  getActiveSpanLlmTags,
   getProvenanceTags,
   mergeProvenanceLlmTags,
   mergeProvenanceTags,
   sanitizeProvenanceTags,
+  setActiveSpanLlmTags,
   setProvenanceTags,
   toProvenanceLlmTags,
   toProvenanceLogTags,
@@ -174,5 +176,16 @@ describe('provenance projections', () => {
 
   it('does not throw when no active span exists', () => {
     expect(() => applyProvenanceToActiveSpan({ 'sandbox.client_type': 'browser' })).not.toThrow();
+  });
+
+  it('tracks active span caller tags in RequestContext for later provenance updates', () => {
+    RequestContext.run({}, () => {
+      const previous = setActiveSpanLlmTags(['task:reply']);
+
+      expect(previous).toBeUndefined();
+      expect(getActiveSpanLlmTags()).toEqual(['task:reply']);
+      expect(setActiveSpanLlmTags(undefined)).toEqual(['task:reply']);
+      expect(getActiveSpanLlmTags()).toEqual([]);
+    });
   });
 });

--- a/nest/src/trace/provenance-tags.ts
+++ b/nest/src/trace/provenance-tags.ts
@@ -2,16 +2,16 @@ import { getAppLogger } from '@app/utils/app-logger';
 
 import { RequestContext } from './request-context';
 
-import { context, trace } from '@opentelemetry/api';
+import { context, createContextKey, trace } from '@opentelemetry/api';
 
-import type { Span } from '@opentelemetry/api';
+import type { Context, Span } from '@opentelemetry/api';
 
 export type ProvenanceTags = Readonly<Record<string, string>>;
 
 const logger = getAppLogger('ProvenanceTags');
 
 const PROVENANCE_TAGS_KEY = 'provenance.tags';
-const ACTIVE_SPAN_LLM_TAGS_KEY = 'provenance.active_span_llm_tags';
+const ACTIVE_SPAN_LLM_TAGS_CONTEXT_KEY = createContextKey('provenance.active_span_llm_tags');
 const MAX_TAGS = 16;
 const MAX_KEY_LENGTH = 64;
 const MAX_VALUE_LENGTH = 256;
@@ -124,16 +124,17 @@ export function clearProvenanceTags(): void {
   RequestContext.set(PROVENANCE_TAGS_KEY, undefined);
 }
 
-export function setActiveSpanLlmTags(tags: readonly string[] | undefined): readonly string[] | undefined {
-  if (!hasRequestContext()) return undefined;
+export function withActiveSpanLlmTags(activeContext: Context, tags: readonly string[] | undefined): Context {
+  if (tags === undefined) {
+    return activeContext.deleteValue(ACTIVE_SPAN_LLM_TAGS_CONTEXT_KEY);
+  }
 
-  const previous = RequestContext.get<readonly string[]>(ACTIVE_SPAN_LLM_TAGS_KEY);
-  RequestContext.set(ACTIVE_SPAN_LLM_TAGS_KEY, tags !== undefined ? [...tags] : undefined);
-  return previous;
+  return activeContext.setValue(ACTIVE_SPAN_LLM_TAGS_CONTEXT_KEY, [...tags]);
 }
 
-export function getActiveSpanLlmTags(): readonly string[] {
-  return RequestContext.get<readonly string[]>(ACTIVE_SPAN_LLM_TAGS_KEY) ?? [];
+export function getActiveSpanLlmTags(activeContext: Context = context.active()): readonly string[] {
+  const tags = activeContext.getValue(ACTIVE_SPAN_LLM_TAGS_CONTEXT_KEY);
+  return Array.isArray(tags) && tags.every((tag) => typeof tag === 'string') ? tags : [];
 }
 
 function sortedEntries(tags: ProvenanceTags | undefined): Array<[string, string]> {

--- a/nest/src/trace/provenance-tags.ts
+++ b/nest/src/trace/provenance-tags.ts
@@ -11,6 +11,7 @@ export type ProvenanceTags = Readonly<Record<string, string>>;
 const logger = getAppLogger('ProvenanceTags');
 
 const PROVENANCE_TAGS_KEY = 'provenance.tags';
+const ACTIVE_SPAN_LLM_TAGS_KEY = 'provenance.active_span_llm_tags';
 const MAX_TAGS = 16;
 const MAX_KEY_LENGTH = 64;
 const MAX_VALUE_LENGTH = 256;
@@ -123,6 +124,18 @@ export function clearProvenanceTags(): void {
   RequestContext.set(PROVENANCE_TAGS_KEY, undefined);
 }
 
+export function setActiveSpanLlmTags(tags: readonly string[] | undefined): readonly string[] | undefined {
+  if (!hasRequestContext()) return undefined;
+
+  const previous = RequestContext.get<readonly string[]>(ACTIVE_SPAN_LLM_TAGS_KEY);
+  RequestContext.set(ACTIVE_SPAN_LLM_TAGS_KEY, tags !== undefined ? [...tags] : undefined);
+  return previous;
+}
+
+export function getActiveSpanLlmTags(): readonly string[] {
+  return RequestContext.get<readonly string[]>(ACTIVE_SPAN_LLM_TAGS_KEY) ?? [];
+}
+
 function sortedEntries(tags: ProvenanceTags | undefined): Array<[string, string]> {
   return Object.entries(sanitizeProvenanceTags(tags)).sort(([a], [b]) => a.localeCompare(b));
 }
@@ -161,5 +174,5 @@ export function applyProvenanceToSpan(
 export function applyProvenanceToActiveSpan(tags: ProvenanceTags = getProvenanceTags()): void {
   const span = trace.getSpan(context.active());
   if (!span) return;
-  applyProvenanceToSpan(span, tags);
+  applyProvenanceToSpan(span, tags, getActiveSpanLlmTags());
 }

--- a/nest/src/trace/provenance-tags.ts
+++ b/nest/src/trace/provenance-tags.ts
@@ -1,128 +1,27 @@
-import { getAppLogger } from '@app/utils/app-logger';
-
-import { RequestContext } from './request-context';
+import {
+  getProvenanceTags,
+  mergeProvenanceTags as mergeContextProvenanceTags,
+  mergeProvenanceLlmTags,
+  setProvenanceTags as setContextProvenanceTags,
+} from './provenance-context';
+import { sortedProvenanceEntries } from './provenance-format';
 
 import { context, createContextKey, trace } from '@opentelemetry/api';
 
+import type { ProvenanceTags } from './provenance-format';
 import type { Context, Span } from '@opentelemetry/api';
 
-export type ProvenanceTags = Readonly<Record<string, string>>;
-
-const logger = getAppLogger('ProvenanceTags');
-
-const PROVENANCE_TAGS_KEY = 'provenance.tags';
 const ACTIVE_SPAN_LLM_TAGS_CONTEXT_KEY = createContextKey('provenance.active_span_llm_tags');
-const MAX_TAGS = 16;
-const MAX_KEY_LENGTH = 64;
-const MAX_VALUE_LENGTH = 256;
-const KEY_PATTERN = /^[a-z0-9_]+(\.[a-z0-9_]+)+$/;
-const SENSITIVE_KEY_PARTS = new Set([
-  'authorization',
-  'cookie',
-  'csrf_token',
-  'id_token',
-  'api_key',
-  'password',
-  'refresh_token',
-  'secret',
-  'token',
-]);
 
-function hasRequestContext(): boolean {
-  return RequestContext.entries() !== undefined;
-}
-
-function isSensitiveKey(key: string): boolean {
-  return key.split('.').some((part) => SENSITIVE_KEY_PARTS.has(part) || part.endsWith('_token'));
-}
-
-function normalizeValue(value: unknown): string | undefined {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
-  }
-
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? String(value) : undefined;
-  }
-
-  if (typeof value === 'boolean') {
-    return String(value);
-  }
-
-  return undefined;
-}
-
-function warnDropped(dropped: number): void {
-  if (dropped > 0) {
-    logger.warning`Dropped ${dropped} invalid provenance tag(s)`;
-  }
-}
-
-export function sanitizeProvenanceTags(
-  input: Record<string, unknown> | undefined,
-  options?: { warn?: boolean },
-): ProvenanceTags {
-  if (!input) return Object.freeze({});
-
-  const output: Record<string, string> = {};
-  let accepted = 0;
-  let dropped = 0;
-
-  for (const [key, rawValue] of Object.entries(input)) {
-    const value = normalizeValue(rawValue);
-    const valid =
-      key.length <= MAX_KEY_LENGTH &&
-      KEY_PATTERN.test(key) &&
-      !isSensitiveKey(key) &&
-      value !== undefined &&
-      value.length <= MAX_VALUE_LENGTH &&
-      accepted < MAX_TAGS;
-
-    if (!valid) {
-      dropped += 1;
-      continue;
-    }
-
-    output[key] = value;
-    accepted += 1;
-  }
-
-  if (options?.warn) {
-    warnDropped(dropped);
-  }
-  return Object.freeze(output);
-}
-
-export function setProvenanceTags(tags: Record<string, unknown>): void {
-  if (!hasRequestContext()) return;
-
-  const sanitized = sanitizeProvenanceTags(tags, { warn: true });
-  RequestContext.set(PROVENANCE_TAGS_KEY, sanitized);
-  applyProvenanceToActiveSpan(sanitized);
-}
-
-export function mergeProvenanceTags(tags: Record<string, unknown>): void {
-  if (!hasRequestContext()) return;
-
-  const merged = {
-    ...getProvenanceTags(),
-    ...sanitizeProvenanceTags(tags, { warn: true }),
-  };
-  const sanitized = sanitizeProvenanceTags(merged);
-  RequestContext.set(PROVENANCE_TAGS_KEY, sanitized);
-  applyProvenanceToActiveSpan(sanitized);
-}
-
-export function getProvenanceTags(): ProvenanceTags {
-  const current = RequestContext.get<Record<string, unknown>>(PROVENANCE_TAGS_KEY);
-  return sanitizeProvenanceTags(current);
-}
-
-export function clearProvenanceTags(): void {
-  if (!hasRequestContext()) return;
-  RequestContext.set(PROVENANCE_TAGS_KEY, undefined);
-}
+export type { ProvenanceTags } from './provenance-format';
+export { sanitizeProvenanceTags } from './provenance-format';
+export {
+  clearProvenanceTags,
+  getProvenanceTags,
+  mergeProvenanceLlmTags,
+  toProvenanceLlmTags,
+  toProvenanceLogTags,
+} from './provenance-context';
 
 export function withActiveSpanLlmTags(activeContext: Context, tags: readonly string[] | undefined): Context {
   if (tags === undefined) {
@@ -137,24 +36,14 @@ export function getActiveSpanLlmTags(activeContext: Context = context.active()):
   return Array.isArray(tags) && tags.every((tag) => typeof tag === 'string') ? tags : [];
 }
 
-function sortedEntries(tags: ProvenanceTags | undefined): Array<[string, string]> {
-  return Object.entries(sanitizeProvenanceTags(tags)).sort(([a], [b]) => a.localeCompare(b));
+export function setProvenanceTags(tags: Record<string, unknown>): void {
+  setContextProvenanceTags(tags);
+  applyProvenanceToActiveSpan();
 }
 
-export function toProvenanceLogTags(tags: ProvenanceTags = getProvenanceTags()): string[] {
-  return sortedEntries(tags).map(([key, value]) => `provenance:${key}=${value}`);
-}
-
-export function toProvenanceLlmTags(tags: ProvenanceTags = getProvenanceTags()): string[] {
-  return sortedEntries(tags).map(([key, value]) => `${key}:${value}`);
-}
-
-export function mergeProvenanceLlmTags(
-  existingTags: readonly string[] = [],
-  tags: ProvenanceTags = getProvenanceTags(),
-): string[] {
-  const provenanceTags = toProvenanceLlmTags(tags);
-  return provenanceTags.length > 0 ? [...existingTags, ...provenanceTags] : [...existingTags];
+export function mergeProvenanceTags(tags: Record<string, unknown>): void {
+  mergeContextProvenanceTags(tags);
+  applyProvenanceToActiveSpan();
 }
 
 export function applyProvenanceToSpan(
@@ -162,7 +51,7 @@ export function applyProvenanceToSpan(
   tags: ProvenanceTags = getProvenanceTags(),
   existingLlmTags: readonly string[] = [],
 ): void {
-  const entries = sortedEntries(tags);
+  const entries = sortedProvenanceEntries(tags);
   if (entries.length === 0) return;
 
   for (const [key, value] of entries) {

--- a/nest/src/trace/provenance-tags.ts
+++ b/nest/src/trace/provenance-tags.ts
@@ -1,0 +1,165 @@
+import { getAppLogger } from '@app/utils/app-logger';
+
+import { RequestContext } from './request-context';
+
+import { context, trace } from '@opentelemetry/api';
+
+import type { Span } from '@opentelemetry/api';
+
+export type ProvenanceTags = Readonly<Record<string, string>>;
+
+const logger = getAppLogger('ProvenanceTags');
+
+const PROVENANCE_TAGS_KEY = 'provenance.tags';
+const MAX_TAGS = 16;
+const MAX_KEY_LENGTH = 64;
+const MAX_VALUE_LENGTH = 256;
+const KEY_PATTERN = /^[a-z0-9_]+(\.[a-z0-9_]+)+$/;
+const SENSITIVE_KEY_PARTS = new Set([
+  'authorization',
+  'cookie',
+  'csrf_token',
+  'id_token',
+  'api_key',
+  'password',
+  'refresh_token',
+  'secret',
+  'token',
+]);
+
+function hasRequestContext(): boolean {
+  return RequestContext.entries() !== undefined;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return key.split('.').some((part) => SENSITIVE_KEY_PARTS.has(part) || part.endsWith('_token'));
+}
+
+function normalizeValue(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function warnDropped(dropped: number): void {
+  if (dropped > 0) {
+    logger.warning`Dropped ${dropped} invalid provenance tag(s)`;
+  }
+}
+
+export function sanitizeProvenanceTags(
+  input: Record<string, unknown> | undefined,
+  options?: { warn?: boolean },
+): ProvenanceTags {
+  if (!input) return Object.freeze({});
+
+  const output: Record<string, string> = {};
+  let accepted = 0;
+  let dropped = 0;
+
+  for (const [key, rawValue] of Object.entries(input)) {
+    const value = normalizeValue(rawValue);
+    const valid =
+      key.length <= MAX_KEY_LENGTH &&
+      KEY_PATTERN.test(key) &&
+      !isSensitiveKey(key) &&
+      value !== undefined &&
+      value.length <= MAX_VALUE_LENGTH &&
+      accepted < MAX_TAGS;
+
+    if (!valid) {
+      dropped += 1;
+      continue;
+    }
+
+    output[key] = value;
+    accepted += 1;
+  }
+
+  if (options?.warn) {
+    warnDropped(dropped);
+  }
+  return Object.freeze(output);
+}
+
+export function setProvenanceTags(tags: Record<string, unknown>): void {
+  if (!hasRequestContext()) return;
+
+  const sanitized = sanitizeProvenanceTags(tags, { warn: true });
+  RequestContext.set(PROVENANCE_TAGS_KEY, sanitized);
+  applyProvenanceToActiveSpan(sanitized);
+}
+
+export function mergeProvenanceTags(tags: Record<string, unknown>): void {
+  if (!hasRequestContext()) return;
+
+  const merged = {
+    ...getProvenanceTags(),
+    ...sanitizeProvenanceTags(tags, { warn: true }),
+  };
+  const sanitized = sanitizeProvenanceTags(merged);
+  RequestContext.set(PROVENANCE_TAGS_KEY, sanitized);
+  applyProvenanceToActiveSpan(sanitized);
+}
+
+export function getProvenanceTags(): ProvenanceTags {
+  const current = RequestContext.get<Record<string, unknown>>(PROVENANCE_TAGS_KEY);
+  return sanitizeProvenanceTags(current);
+}
+
+export function clearProvenanceTags(): void {
+  if (!hasRequestContext()) return;
+  RequestContext.set(PROVENANCE_TAGS_KEY, undefined);
+}
+
+function sortedEntries(tags: ProvenanceTags | undefined): Array<[string, string]> {
+  return Object.entries(sanitizeProvenanceTags(tags)).sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function toProvenanceLogTags(tags: ProvenanceTags = getProvenanceTags()): string[] {
+  return sortedEntries(tags).map(([key, value]) => `provenance:${key}=${value}`);
+}
+
+export function toProvenanceLlmTags(tags: ProvenanceTags = getProvenanceTags()): string[] {
+  return sortedEntries(tags).map(([key, value]) => `${key}:${value}`);
+}
+
+export function mergeProvenanceLlmTags(
+  existingTags: readonly string[] = [],
+  tags: ProvenanceTags = getProvenanceTags(),
+): string[] {
+  const provenanceTags = toProvenanceLlmTags(tags);
+  return provenanceTags.length > 0 ? [...existingTags, ...provenanceTags] : [...existingTags];
+}
+
+export function applyProvenanceToSpan(
+  span: Span,
+  tags: ProvenanceTags = getProvenanceTags(),
+  existingLlmTags: readonly string[] = [],
+): void {
+  const entries = sortedEntries(tags);
+  if (entries.length === 0) return;
+
+  for (const [key, value] of entries) {
+    span.setAttribute(`provenance.${key}`, value);
+  }
+
+  span.setAttribute('ai.telemetry.metadata.tags', mergeProvenanceLlmTags(existingLlmTags, tags));
+}
+
+export function applyProvenanceToActiveSpan(tags: ProvenanceTags = getProvenanceTags()): void {
+  const span = trace.getSpan(context.active());
+  if (!span) return;
+  applyProvenanceToSpan(span, tags);
+}

--- a/nest/src/trace/telemetry-span.ts
+++ b/nest/src/trace/telemetry-span.ts
@@ -1,4 +1,5 @@
 import { LangfuseContract } from './langfuse/contract';
+import { applyProvenanceToSpan, mergeProvenanceLlmTags } from './provenance-tags';
 import { RequestContext } from './request-context';
 
 import { context as otelContext, trace } from '@opentelemetry/api';
@@ -83,7 +84,7 @@ export async function withTelemetrySpan<T>(options: TelemetrySpanOptions<T>): Pr
         name: traceMeta?.name,
         userId: traceMeta?.userId ?? RequestContext.get<string>('userId'),
         sessionId: traceMeta?.sessionId ?? RequestContext.get<string>('threadId'),
-        tags: traceMeta?.tags,
+        tags: mergeProvenanceLlmTags(traceMeta?.tags),
       };
 
       // 检查是否已设置 trace name（避免重复设置）
@@ -102,6 +103,8 @@ export async function withTelemetrySpan<T>(options: TelemetrySpanOptions<T>): Pr
           span.setAttribute('langfuse.session.id', effectiveTraceMeta.sessionId);
         }
       }
+
+      applyProvenanceToSpan(span, undefined, traceMeta?.tags);
 
       // 2. 设置初始 attributes
       if (attributes) {
@@ -168,7 +171,7 @@ export function withTelemetryGenerator<T, TReturn = void>(
     name: traceMeta?.name,
     userId: traceMeta?.userId ?? RequestContext.get<string>('userId'),
     sessionId: traceMeta?.sessionId ?? RequestContext.get<string>('threadId'),
-    tags: traceMeta?.tags,
+    tags: mergeProvenanceLlmTags(traceMeta?.tags),
   };
 
   const traceNameAlreadySet = RequestContext.get<boolean>('langfuse.trace.name.set');
@@ -177,6 +180,8 @@ export function withTelemetryGenerator<T, TReturn = void>(
     LangfuseContract.setTraceMetadata(span, effectiveTraceMeta);
     RequestContext.set('langfuse.trace.name.set', true);
   }
+
+  applyProvenanceToSpan(span, undefined, traceMeta?.tags);
 
   if (attributes) {
     setSpanAttributes(span, attributes);

--- a/nest/src/trace/telemetry-span.ts
+++ b/nest/src/trace/telemetry-span.ts
@@ -1,5 +1,5 @@
 import { LangfuseContract } from './langfuse/contract';
-import { applyProvenanceToSpan, mergeProvenanceLlmTags } from './provenance-tags';
+import { applyProvenanceToSpan, mergeProvenanceLlmTags, setActiveSpanLlmTags } from './provenance-tags';
 import { RequestContext } from './request-context';
 
 import { context as otelContext, trace } from '@opentelemetry/api';
@@ -78,6 +78,7 @@ export async function withTelemetrySpan<T>(options: TelemetrySpanOptions<T>): Pr
   }
 
   return tracer.startActiveSpan(name, {}, activeCtx, async (span) => {
+    const previousSpanLlmTags = setActiveSpanLlmTags(traceMeta?.tags);
     try {
       // 1. 设置 trace 元数据（从 options 或 RequestContext）
       const effectiveTraceMeta: TraceMetadata = {
@@ -140,6 +141,7 @@ export async function withTelemetrySpan<T>(options: TelemetrySpanOptions<T>): Pr
       LangfuseContract.error(span, error instanceof Error ? error : new Error(String(error)));
       throw error;
     } finally {
+      setActiveSpanLlmTags(previousSpanLlmTags);
       span.end();
     }
   });
@@ -165,6 +167,7 @@ export function withTelemetryGenerator<T, TReturn = void>(
   }
 
   const span = tracer.startSpan(name, {}, activeCtx);
+  const previousSpanLlmTags = setActiveSpanLlmTags(traceMeta?.tags);
 
   // 设置 trace 元数据
   const effectiveTraceMeta: TraceMetadata = {
@@ -187,8 +190,17 @@ export function withTelemetryGenerator<T, TReturn = void>(
     setSpanAttributes(span, attributes);
   }
 
+  const source = factory(span);
+  async function* generatorWithSpanLlmTags(): AsyncGenerator<T, TReturn> {
+    try {
+      return yield* source;
+    } finally {
+      setActiveSpanLlmTags(previousSpanLlmTags);
+    }
+  }
+
   // 返回 generator 和 span，由调用者负责结束 span
-  return { generator: factory(span), span };
+  return { generator: generatorWithSpanLlmTags(), span };
 }
 
 /**

--- a/nest/src/trace/telemetry-span.ts
+++ b/nest/src/trace/telemetry-span.ts
@@ -1,5 +1,5 @@
 import { LangfuseContract } from './langfuse/contract';
-import { applyProvenanceToSpan, mergeProvenanceLlmTags, setActiveSpanLlmTags } from './provenance-tags';
+import { applyProvenanceToSpan, mergeProvenanceLlmTags, withActiveSpanLlmTags } from './provenance-tags';
 import { RequestContext } from './request-context';
 
 import { context as otelContext, trace } from '@opentelemetry/api';
@@ -76,9 +76,9 @@ export async function withTelemetrySpan<T>(options: TelemetrySpanOptions<T>): Pr
   if (parentContext) {
     activeCtx = trace.setSpanContext(activeCtx, parentContext);
   }
+  activeCtx = withActiveSpanLlmTags(activeCtx, traceMeta?.tags);
 
   return tracer.startActiveSpan(name, {}, activeCtx, async (span) => {
-    const previousSpanLlmTags = setActiveSpanLlmTags(traceMeta?.tags);
     try {
       // 1. 设置 trace 元数据（从 options 或 RequestContext）
       const effectiveTraceMeta: TraceMetadata = {
@@ -141,7 +141,6 @@ export async function withTelemetrySpan<T>(options: TelemetrySpanOptions<T>): Pr
       LangfuseContract.error(span, error instanceof Error ? error : new Error(String(error)));
       throw error;
     } finally {
-      setActiveSpanLlmTags(previousSpanLlmTags);
       span.end();
     }
   });
@@ -165,9 +164,9 @@ export function withTelemetryGenerator<T, TReturn = void>(
   if (parentContext) {
     activeCtx = trace.setSpanContext(activeCtx, parentContext);
   }
+  activeCtx = withActiveSpanLlmTags(activeCtx, traceMeta?.tags);
 
   const span = tracer.startSpan(name, {}, activeCtx);
-  const previousSpanLlmTags = setActiveSpanLlmTags(traceMeta?.tags);
 
   // 设置 trace 元数据
   const effectiveTraceMeta: TraceMetadata = {
@@ -190,17 +189,8 @@ export function withTelemetryGenerator<T, TReturn = void>(
     setSpanAttributes(span, attributes);
   }
 
-  const source = factory(span);
-  async function* generatorWithSpanLlmTags(): AsyncGenerator<T, TReturn> {
-    try {
-      return yield* source;
-    } finally {
-      setActiveSpanLlmTags(previousSpanLlmTags);
-    }
-  }
-
   // 返回 generator 和 span，由调用者负责结束 span
-  return { generator: generatorWithSpanLlmTags(), span };
+  return { generator: factory(span), span };
 }
 
 /**


### PR DESCRIPTION
## Goal

Add a low-entropy request-scoped provenance tag lane that can be projected consistently into logs, OpenTelemetry/Langfuse spans, and AI SDK telemetry without reading ad hoc request headers or introducing baggage propagation.

## Non-goals

- No business-side sandbox protocol adapter in this PR.
- No baggage propagation.
- No docs changes.
- No unrelated dependency/package changes.

## Spec review

- Boundary: provenance enters through explicit `setProvenanceTags` / `mergeProvenanceTags` APIs only; outside `RequestContext` they no-op.
- Normalization: keys must be namespaced dotted lowercase tokens, values must be scalar strings/numbers/booleans, limits are enforced, invalid and sensitive keys are dropped with warn at the mutation boundary.
- Output contract: logs receive `provenance:key=value`; spans receive `provenance.*` attributes; Langfuse / AI telemetry tags preserve caller tags first and append provenance tags.
- Observability: invalid provenance input is warned but never throws or breaks the request path.
- Regression boundary: no baggage APIs and no request header parsing were introduced.

## Verification

- `bun test nest/src/trace/provenance-tags.spec.ts features/llm/clients/provenance-runtime-context.spec.ts`
- `bun run typecheck`
- `bunx prettier --check ...`
- `bunx eslint ... --no-warn-ignored` (0 errors; existing deprecation warnings only)
- `bun test` (465 pass / 0 fail)
- pre-commit hook: `tsc --noEmit` + `bun test` passed
- pre-push hook: `tsc --noEmit` + `eslint . --fix` + `bun test` passed; ESLint emitted existing warnings only