### PR TITLE
Add provider-namespaced LLM routing options

### DIFF
--- a/features/llm/clients/index.ts
+++ b/features/llm/clients/index.ts
@@ -40,8 +40,14 @@ export {
   vertex,
   vertexGlobal,
 } from './llm.clients';
-// 工厂函数（需要自定义配置时使用）
-export { createOpenRouterClient, openrouterOptions } from './openrouter.client';
+// 工厂函数与 OpenRouter 扩展点（需要自定义配置时使用）
+export {
+  createOpenRouterClient,
+  getOpenRouterRoutingProfile,
+  openrouterOptions,
+  registerOpenRouterRoutingProfile,
+  type OpenRouterRoutingProfile,
+} from './openrouter.client';
 
 // 场景化辅助
 export * from './options.helpers';

--- a/features/llm/clients/llm.ai-options.integration.spec.ts
+++ b/features/llm/clients/llm.ai-options.integration.spec.ts
@@ -169,4 +169,87 @@ describe('LLM ai namespace', () => {
     expect(capturedRequests[0]!.url).toContain('openrouter.ai');
     expect(capturedRequests[1]!.url).toContain('aiplatform.googleapis.com');
   });
+
+  it('model spec openrouter.routing=bedrock emits Bedrock-only provider routing', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'ai-openrouter-routing-bedrock',
+        model: 'openrouter:claude-sonnet-4.5?openrouter.routing=bedrock',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    const body = firstJsonBody();
+    expect(body.provider).toEqual({
+      only: ['amazon-bedrock'],
+      allow_fallbacks: false,
+    });
+  });
+
+  it('call-level openrouter provider routing overrides model spec routing', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'ai-openrouter-routing-call-override',
+        model: 'openrouter:claude-sonnet-4.5?openrouter.routing=latency',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+        openrouter: {
+          provider: {
+            only: ['amazon-bedrock'],
+            allowFallbacks: false,
+          },
+        },
+      }),
+    );
+
+    const body = firstJsonBody();
+    expect(body.provider).toEqual({
+      only: ['amazon-bedrock'],
+      allow_fallbacks: false,
+    });
+  });
+
+  it('legacy providerSort still emits OpenRouter provider.sort', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'ai-openrouter-provider-sort',
+        model: 'openrouter:claude-sonnet-4.5',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+        providerSort: 'latency',
+      }),
+    );
+
+    const body = firstJsonBody();
+    expect(body.provider).toEqual({ sort: 'latency' });
+  });
+
+  it('prepareStep.llm.openrouter overrides current OpenRouter routing', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'ai-prepareStep-openrouter-routing',
+        model: 'openrouter:claude-sonnet-4.5?openrouter.routing=latency',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+        ai: {
+          prepareStep: () => ({
+            llm: {
+              openrouter: {
+                provider: {
+                  only: ['amazon-bedrock'],
+                  allowFallbacks: false,
+                },
+              },
+            },
+          }),
+        },
+      }),
+    );
+
+    const body = firstJsonBody();
+    const provider = body.provider as Record<string, unknown>;
+    expect(provider.only).toEqual(['amazon-bedrock']);
+    expect(provider.allow_fallbacks).toBe(false);
+  });
 });

--- a/features/llm/clients/llm.class.ts
+++ b/features/llm/clients/llm.class.ts
@@ -39,6 +39,7 @@ import { DEFAULT_SUPPORTED_TIERS, getModel, parseModelSpec } from '../types/mode
 import { getCostFromUsage } from '../utils/cost-calculator';
 import { model as createModel, parseProvider } from './auto.client';
 import { getOpenAI, getOpenRouter } from './llm.clients';
+import { mergeOpenRouterOptions, resolveOpenRouterOptions } from './openrouter.client';
 import { disableThinkingOptions, reasoningEffortOptions } from './options.helpers';
 
 import { Temporal } from '@js-temporal/polyfill';
@@ -59,7 +60,14 @@ import {
 import { ResultAsync } from 'neverthrow';
 
 import type { EmbeddingModel, EmbeddingModelKey, EmbeddingProvider, EmbeddingTaskType } from '../types/embedding.types';
-import type { LLMModelKey, LLMModelSpec, VertexRequestType, VertexTier } from '../types/model.types';
+import type {
+  LLMModelKey,
+  LLMModelSpec,
+  OpenRouterModelOptions,
+  OpenRouterProviderSort,
+  VertexRequestType,
+  VertexTier,
+} from '../types/model.types';
 /**
  * 仅对已知会包裹 markdown 代码块的模型启用 extractJsonMiddleware。
  *
@@ -140,7 +148,7 @@ export interface TokenUsage {
 }
 
 /** OpenRouter Provider 排序策略 */
-export type ProviderSort = 'price' | 'throughput' | 'latency';
+export type ProviderSort = OpenRouterProviderSort;
 
 type LLMReservedAIKeys = 'model' | 'providerOptions';
 type LLMWrappedAIKeys = LLMReservedAIKeys | 'prepareStep';
@@ -152,6 +160,8 @@ export interface LLMPrepareStepOptions {
   thinking?: ThinkingEffort;
   /** OpenRouter provider ordering override for the step model. */
   providerSort?: ProviderSort;
+  /** OpenRouter provider routing override for the step model. */
+  openrouter?: OpenRouterModelOptions;
   /** Provider model id suffix for the step model. */
   modelIdSuffix?: string;
 }
@@ -211,6 +221,8 @@ interface BaseParams {
    * - 'latency': 优先最低延迟
    */
   providerSort?: ProviderSort;
+  /** OpenRouter provider routing options（仅 openrouter 有效） */
+  openrouter?: OpenRouterModelOptions;
   /** 温度 */
   temperature?: number;
   /** 最大输出 token */
@@ -336,6 +348,7 @@ interface GenerateTextResult {
 /** resolveSpec 返回值 */
 interface ResolvedSpec {
   key: LLMModelKey;
+  provider: ProviderType;
   thinking: ThinkingEffort;
   maxRetries: number;
   timeout: number;
@@ -344,6 +357,8 @@ interface ResolvedSpec {
   tier: VertexTier | undefined;
   /** Vertex request type（仅 vertex / vertex-global + tier=flex/priority 时生效） */
   vertexRequestType: VertexRequestType | undefined;
+  /** OpenRouter provider-namespaced options. */
+  openrouter: OpenRouterModelOptions | undefined;
 }
 
 const specLogger = getAppLogger('features', 'LLM', 'spec');
@@ -368,6 +383,7 @@ function resolveSpec(
   const fallbackModels = parsed.fallbackModels;
   const tier = parsed.tier;
   const vertexRequestType = parsed.vertexRequestType;
+  const openrouter = parsed.openrouter;
 
   // 有非默认参数时打印生效值，方便排查
   const hasSpecParams =
@@ -376,7 +392,8 @@ function resolveSpec(
     parsed.timeout !== undefined ||
     fallbackModels.length > 0 ||
     tier !== undefined ||
-    vertexRequestType !== undefined;
+    vertexRequestType !== undefined ||
+    openrouter !== undefined;
   if (hasSpecParams) {
     const parts: string[] = [];
     if (thinking !== 'none') parts.push(`thinking=${thinking}`);
@@ -385,10 +402,33 @@ function resolveSpec(
     if (fallbackModels.length > 0) parts.push(`fallback=[${fallbackModels.join(',')}]`);
     if (tier !== undefined) parts.push(`tier=${tier}`);
     if (vertexRequestType !== undefined) parts.push(`vertexRequestType=${vertexRequestType}`);
+    if (openrouter?.routing !== undefined) parts.push(`openrouter.routing=${openrouter.routing}`);
     specLogger.info`[resolveSpec] ${parsed.key} → ${parts.join(', ')}`;
   }
 
-  return { key: parsed.key, thinking, maxRetries, timeout, fallbackModels, tier, vertexRequestType };
+  return {
+    key: parsed.key,
+    provider: parsed.provider,
+    thinking,
+    maxRetries,
+    timeout,
+    fallbackModels,
+    tier,
+    vertexRequestType,
+    openrouter,
+  };
+}
+
+function resolveOpenRouterCallOptions(
+  specOpenRouter: OpenRouterModelOptions | undefined,
+  providerSort: ProviderSort | undefined,
+  callOpenRouter: OpenRouterModelOptions | undefined,
+): OpenRouterModelOptions | undefined {
+  const legacyProviderSort = providerSort ? { provider: { sort: providerSort } } : undefined;
+  if (callOpenRouter) {
+    return mergeOpenRouterOptions(legacyProviderSort, callOpenRouter);
+  }
+  return legacyProviderSort ?? specOpenRouter;
 }
 
 /**
@@ -401,7 +441,7 @@ function buildProviderOptions(
   provider: ProviderType,
   thinking: ThinkingEffort,
   modelKey: LLMModelKey,
-  providerSort?: ProviderSort,
+  openrouter?: OpenRouterModelOptions,
 ): ProviderOptionsSurface {
   const modelConfig = getModel(modelKey);
   const thinkingOptions: ProviderOptionsSurface =
@@ -411,12 +451,24 @@ function buildProviderOptions(
         : disableThinkingOptions(provider)
       : reasoningEffortOptions(provider, thinking);
 
-  // 只有 openrouter 支持 providerSort
-  if (provider === 'openrouter' && providerSort) {
+  if (provider !== 'openrouter') {
+    if (openrouter) {
+      aiLogger.warning`[buildProviderOptions] openrouter options requested for non-openrouter provider=${provider} (model=${modelKey}), ignoring`;
+    }
+    return thinkingOptions;
+  }
+
+  const routingOptions = resolveOpenRouterOptions(
+    openrouter,
+    (name) =>
+      { aiLogger.warning`[buildProviderOptions] unknown OpenRouter routing profile="${name}" (model=${modelKey}), ignoring`; },
+  );
+
+  if (routingOptions?.openrouter) {
     return {
       openrouter: {
         ...thinkingOptions.openrouter,
-        provider: { sort: providerSort },
+        ...routingOptions.openrouter,
       },
     };
   }
@@ -494,6 +546,7 @@ interface ResolveAIOptionsContext {
   modelIdSuffix?: string;
   thinking: ThinkingEffort;
   providerSort?: ProviderSort;
+  openrouter?: OpenRouterModelOptions;
   extractJson?: boolean;
 }
 
@@ -540,17 +593,17 @@ function wrapPrepareStep<TOOLS extends ToolSet, RUNTIME_CONTEXT extends Context>
     }
 
     const provider = parseProvider(stepSpec.key);
+    const stepOpenRouter = resolveOpenRouterCallOptions(
+      llmOptions.model ? stepSpec.openrouter : context.openrouter,
+      llmOptions.providerSort ?? (llmOptions.openrouter ? undefined : context.providerSort),
+      llmOptions.openrouter,
+    );
     return {
       ...safe,
       model: createLanguageModelForCall(stepSpec.key, targetModelIdSuffix, {
         extractJson: context.extractJson,
       }),
-      providerOptions: buildProviderOptions(
-        provider,
-        stepSpec.thinking,
-        stepSpec.key,
-        llmOptions.providerSort ?? context.providerSort,
-      ),
+      providerOptions: buildProviderOptions(provider, stepSpec.thinking, stepSpec.key, stepOpenRouter),
     };
   };
 }
@@ -1067,6 +1120,7 @@ export class LLM {
       messages,
       thinking: callerThinking = 'none',
       providerSort,
+      openrouter,
       temperature,
       maxOutputTokens,
       abortSignal,
@@ -1076,6 +1130,7 @@ export class LLM {
     } = params;
 
     const spec = resolveSpec(modelSpec, callerThinking, callerMaxRetries, callerTimeout);
+    const openrouterOptions = resolveOpenRouterCallOptions(spec.openrouter, providerSort, openrouter);
 
     return withFallback(id, 'generateObject', spec, async (modelKey, fb) => {
       const startTime = Date.now();
@@ -1085,7 +1140,7 @@ export class LLM {
 
       const languageModel = createModel(modelKey);
       const provider = parseProvider(modelKey);
-      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, providerSort);
+      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
       const tierHeaders = buildTierHeaders(modelKey, spec.tier, spec.vertexRequestType);
 
       const { signal, cleanup } = createManagedSignal(spec.timeout, abortSignal);
@@ -1275,6 +1330,7 @@ export class LLM {
       messages,
       thinking: callerThinking = 'none',
       providerSort,
+      openrouter,
       temperature,
       maxOutputTokens,
       abortSignal,
@@ -1287,6 +1343,7 @@ export class LLM {
     } = params;
 
     const spec = resolveSpec(modelSpec, callerThinking, callerMaxRetries, callerTimeout);
+    const openrouterOptions = resolveOpenRouterCallOptions(spec.openrouter, providerSort, openrouter);
     const telemetry = callerTelemetry ?? ai?.telemetry ?? DEFAULT_TELEMETRY;
 
     return withFallback(id, 'generateText', spec, async (modelKey, fb) => {
@@ -1302,12 +1359,13 @@ export class LLM {
           modelIdSuffix,
           thinking: spec.thinking,
           providerSort,
+          openrouter: openrouterOptions,
         },
         { tools },
       );
       const languageModel = createLanguageModelForCall(modelKey, modelIdSuffix);
       const provider = parseProvider(modelKey);
-      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, providerSort);
+      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
       const tierHeaders = buildTierHeaders(modelKey, spec.tier, spec.vertexRequestType);
       const headers = mergeHeaders(aiOptions?.headers, tierHeaders);
 
@@ -1385,6 +1443,7 @@ export class LLM {
       messages,
       thinking: callerThinking = 'none',
       providerSort,
+      openrouter,
       temperature,
       maxOutputTokens,
       abortSignal,
@@ -1397,6 +1456,7 @@ export class LLM {
     } = params;
 
     const spec = resolveSpec(modelSpec, callerThinking, callerMaxRetries, callerTimeout);
+    const openrouterOptions = resolveOpenRouterCallOptions(spec.openrouter, providerSort, openrouter);
     const aiOptions = resolveLLMAIOptions<TOOLS, RUNTIME_CONTEXT, LLMStreamTextAIOptions<TOOLS, RUNTIME_CONTEXT>>(
       ai,
       {
@@ -1405,6 +1465,7 @@ export class LLM {
         modelSpec,
         thinking: spec.thinking,
         providerSort,
+        openrouter: openrouterOptions,
         extractJson: true,
       },
       { tools, stopWhen },
@@ -1421,7 +1482,7 @@ export class LLM {
     const model = createLanguageModelForCall(modelKey, undefined, { extractJson: true });
 
     const provider = parseProvider(modelKey);
-    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, providerSort);
+    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
     const tierHeaders = buildTierHeaders(modelKey, spec.tier, spec.vertexRequestType);
     const headers = mergeHeaders(aiOptions?.headers, tierHeaders);
 
@@ -1499,6 +1560,7 @@ export class LLM {
       messages,
       thinking: callerThinking = 'none',
       providerSort,
+      openrouter,
       temperature,
       maxOutputTokens,
       abortSignal,
@@ -1509,12 +1571,14 @@ export class LLM {
     } = params;
 
     const spec = resolveSpec(modelSpec, callerThinking, callerMaxRetries, callerTimeout);
+    const openrouterOptions = resolveOpenRouterCallOptions(spec.openrouter, providerSort, openrouter);
     const aiOptions = resolveLLMAIOptions<TOOLS, RUNTIME_CONTEXT, LLMStreamTextAIOptions<TOOLS, RUNTIME_CONTEXT>>(ai, {
       id,
       method: 'streamText',
       modelSpec,
       thinking: spec.thinking,
       providerSort,
+      openrouter: openrouterOptions,
     });
     const telemetry = callerTelemetry ?? aiOptions?.telemetry ?? DEFAULT_TELEMETRY;
     const { key: modelKey } = spec;
@@ -1525,7 +1589,7 @@ export class LLM {
 
     const languageModel = createLanguageModelForCall(modelKey, undefined);
     const provider = parseProvider(modelKey);
-    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, providerSort);
+    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
     const tierHeaders = buildTierHeaders(modelKey, spec.tier, spec.vertexRequestType);
     const headers = mergeHeaders(aiOptions?.headers, tierHeaders);
 
@@ -1617,6 +1681,7 @@ export class LLM {
       messages,
       thinking: callerThinking = 'none',
       providerSort,
+      openrouter,
       temperature,
       maxOutputTokens,
       abortSignal,
@@ -1629,6 +1694,7 @@ export class LLM {
     } = params;
 
     const spec = resolveSpec(modelSpec, callerThinking, callerMaxRetries, callerTimeout);
+    const openrouterOptions = resolveOpenRouterCallOptions(spec.openrouter, providerSort, openrouter);
 
     return withFallback(id, 'generateObjectViaTool', spec, async (modelKey, fb) => {
       const startTime = Date.now();
@@ -1641,7 +1707,7 @@ export class LLM {
 
       const languageModel = createModel(modelKey);
       const provider = parseProvider(modelKey);
-      const baseProviderOptions = buildProviderOptions(provider, spec.thinking, modelKey, providerSort);
+      const baseProviderOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
 
       // OpenRouter 支持 parallelToolCalls 参数控制并行 tool call
       const providerOptions =
@@ -1803,6 +1869,7 @@ export class LLM {
       messages,
       thinking: callerThinking = 'none',
       providerSort,
+      openrouter,
       temperature,
       maxOutputTokens,
       abortSignal,
@@ -1814,6 +1881,7 @@ export class LLM {
     } = params;
 
     const spec = resolveSpec(modelSpec, callerThinking, callerMaxRetries, callerTimeout);
+    const openrouterOptions = resolveOpenRouterCallOptions(spec.openrouter, providerSort, openrouter);
     const { key: modelKey } = spec;
     if (spec.fallbackModels.length > 0) {
       fallbackLogger.warning`[LLM:fallback-ignored] id=${id}, method=streamObjectViaTool — stream methods do not support fallback, only primary model=${modelKey} will be used. fallback=[${spec.fallbackModels.join(',')}]`;
@@ -1822,7 +1890,7 @@ export class LLM {
 
     const languageModel = createModel(modelKey);
     const provider = parseProvider(modelKey);
-    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, providerSort);
+    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
     const tierHeaders = buildTierHeaders(modelKey, spec.tier, spec.vertexRequestType);
 
     // 创建 Tool，将 Schema 作为 inputSchema

--- a/features/llm/clients/llm.tier.spec.ts
+++ b/features/llm/clients/llm.tier.spec.ts
@@ -24,6 +24,15 @@ import type { LLMModelSpec, VertexTier } from '../types/model.types';
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('parseModelSpec: ?tier query parameter', () => {
+  it('parses namespaced vertex.tier and vertex.requestType', () => {
+    const spec = 'vertex:gemini-2.5-flash?vertex.tier=priority&vertex.requestType=shared' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.key).toBe('vertex:gemini-2.5-flash');
+    expect(result.tier).toBe('priority');
+    expect(result.vertexRequestType).toBe('shared');
+    expect(result.vertex).toEqual({ tier: 'priority', requestType: 'shared' });
+  });
+
   it('parses ?tier=flex', () => {
     const spec = 'vertex:gemini-3.1-flash-lite?tier=flex' as LLMModelSpec;
     const result = parseModelSpec(spec);
@@ -81,6 +90,15 @@ describe('parseModelSpec: ?tier query parameter', () => {
     const result = parseModelSpec(spec);
     expect(result.tier).toBe('priority');
     expect(result.vertexRequestType).toBeUndefined();
+  });
+
+  it('ignores namespaced vertex options on non-vertex providers', () => {
+    const spec = 'openrouter:claude-sonnet-4.5?vertex.tier=flex&vertex.requestType=shared' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.key).toBe('openrouter:claude-sonnet-4.5');
+    expect(result.tier).toBeUndefined();
+    expect(result.vertexRequestType).toBeUndefined();
+    expect(result.vertex).toBeUndefined();
   });
 });
 

--- a/features/llm/clients/openrouter.client.spec.ts
+++ b/features/llm/clients/openrouter.client.spec.ts
@@ -1,0 +1,95 @@
+import 'reflect-metadata';
+
+import {
+  getOpenRouterRoutingProfile as getPublicOpenRouterRoutingProfile,
+  registerOpenRouterRoutingProfile as registerPublicOpenRouterRoutingProfile,
+} from '../index';
+import { openrouterOptions, registerOpenRouterRoutingProfile, resolveOpenRouterOptions } from './openrouter.client';
+
+import { describe, expect, it } from 'bun:test';
+
+import type { OpenRouterRoutingProfile } from '../index';
+
+describe('OpenRouter routing options', () => {
+  it('resolves the built-in bedrock profile to provider.only without fallbacks', () => {
+    const options = resolveOpenRouterOptions({ routing: 'bedrock' });
+
+    expect(options).toEqual({
+      openrouter: {
+        provider: {
+          only: ['amazon-bedrock'],
+          allow_fallbacks: false,
+        },
+      },
+    });
+  });
+
+  it('resolves the built-in latency profile to provider.sort', () => {
+    const options = resolveOpenRouterOptions({ routing: 'latency' });
+
+    expect(options).toEqual({
+      openrouter: {
+        provider: {
+          sort: 'latency',
+        },
+      },
+    });
+  });
+
+  it('returns no provider override for auto routing', () => {
+    expect(resolveOpenRouterOptions({ routing: 'auto' })).toBeUndefined();
+  });
+
+  it('normalizes typed provider routing to OpenRouter snake_case payload', () => {
+    const options = openrouterOptions({
+      provider: {
+        only: ['amazon-bedrock'],
+        ignore: ['openai'],
+        allowFallbacks: false,
+        requireParameters: true,
+      },
+    });
+
+    expect(options.openrouter.provider).toEqual({
+      only: ['amazon-bedrock'],
+      ignore: ['openai'],
+      allow_fallbacks: false,
+      require_parameters: true,
+    });
+  });
+
+  it('lets projects register additional routing profiles', () => {
+    registerOpenRouterRoutingProfile('test-bedrock-prefer', {
+      kind: 'provider',
+      provider: {
+        order: ['amazon-bedrock'],
+        allowFallbacks: true,
+      },
+    });
+
+    const options = resolveOpenRouterOptions({ routing: 'test-bedrock-prefer' });
+
+    expect(options).toEqual({
+      openrouter: {
+        provider: {
+          order: ['amazon-bedrock'],
+          allow_fallbacks: true,
+        },
+      },
+    });
+  });
+
+  it('exports the routing profile registry through the public LLM barrel', () => {
+    const profile: OpenRouterRoutingProfile = {
+      kind: 'provider',
+      provider: {
+        only: ['amazon-bedrock'],
+        allowFallbacks: false,
+      },
+    };
+
+    registerPublicOpenRouterRoutingProfile('test-public-bedrock-only', profile);
+
+    expect(getPublicOpenRouterRoutingProfile('test-public-bedrock-only')).toEqual(profile);
+  });
+});

--- a/features/llm/clients/openrouter.client.ts
+++ b/features/llm/clients/openrouter.client.ts
@@ -6,6 +6,9 @@
 
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 
+import type { OpenRouterModelOptions, OpenRouterProviderRouting, OpenRouterProviderSort } from '../types/model.types';
+import type { JSONObject } from '@ai-sdk/provider';
+
 // 延迟导入 ApiFetcher，避免循环依赖
 let cachedFetch: typeof fetch | undefined;
 async function getProxyFetch(): Promise<typeof fetch> {
@@ -22,6 +25,96 @@ export interface OpenRouterClientOptions {
   useProxy?: boolean;
   /** 自定义 fetch（不推荐，除非有特殊需求） */
   customFetch?: typeof fetch;
+}
+
+export type OpenRouterRoutingProfile = { kind: 'auto' } | { kind: 'provider'; provider: OpenRouterProviderRouting };
+
+const openRouterRoutingProfiles = new Map<string, OpenRouterRoutingProfile>([
+  ['auto', { kind: 'auto' }],
+  ['latency', { kind: 'provider', provider: { sort: 'latency' } }],
+  ['bedrock', { kind: 'provider', provider: { only: ['amazon-bedrock'], allowFallbacks: false } }],
+]);
+
+export function registerOpenRouterRoutingProfile(name: string, profile: OpenRouterRoutingProfile): void {
+  openRouterRoutingProfiles.set(name, profile);
+}
+
+export function getOpenRouterRoutingProfile(name: string): OpenRouterRoutingProfile | undefined {
+  return openRouterRoutingProfiles.get(name);
+}
+
+export function mergeOpenRouterProviderRouting(
+  ...routings: Array<OpenRouterProviderRouting | undefined>
+): OpenRouterProviderRouting | undefined {
+  let merged: OpenRouterProviderRouting | undefined;
+  for (const routing of routings) {
+    if (!routing) continue;
+    merged = {
+      ...(merged ?? {}),
+      ...routing,
+      ...(merged?.extra || routing.extra ? { extra: { ...(merged?.extra ?? {}), ...(routing.extra ?? {}) } } : {}),
+    };
+  }
+  return merged;
+}
+
+export function mergeOpenRouterOptions(
+  ...options: Array<OpenRouterModelOptions | undefined>
+): OpenRouterModelOptions | undefined {
+  let routing: string | undefined;
+  let provider: OpenRouterProviderRouting | undefined;
+
+  for (const option of options) {
+    if (!option) continue;
+    if (option.routing !== undefined) {
+      routing = option.routing;
+    }
+    provider = mergeOpenRouterProviderRouting(provider, option.provider);
+  }
+
+  return routing !== undefined || provider !== undefined
+    ? {
+        ...(routing !== undefined ? { routing } : {}),
+        ...(provider !== undefined ? { provider } : {}),
+      }
+    : undefined;
+}
+
+function normalizeOpenRouterProviderRouting(routing: OpenRouterProviderRouting | undefined): JSONObject | undefined {
+  if (!routing) return undefined;
+
+  const { order, only, ignore, allowFallbacks, requireParameters, sort, extra } = routing;
+  const payload: Record<string, unknown> = {
+    ...(order !== undefined ? { order: [...order] } : {}),
+    ...(only !== undefined ? { only: [...only] } : {}),
+    ...(ignore !== undefined ? { ignore: [...ignore] } : {}),
+    ...(allowFallbacks !== undefined ? { allow_fallbacks: allowFallbacks } : {}),
+    ...(requireParameters !== undefined ? { require_parameters: requireParameters } : {}),
+    ...(sort !== undefined ? { sort } : {}),
+    ...(extra ?? {}),
+  };
+
+  return Object.keys(payload).length > 0 ? (payload as JSONObject) : undefined;
+}
+
+export function resolveOpenRouterOptions(
+  options: OpenRouterModelOptions | undefined,
+  onUnknownProfile?: (name: string) => void,
+): { openrouter?: JSONObject } | undefined {
+  if (!options) return undefined;
+
+  const profile = options.routing !== undefined ? getOpenRouterRoutingProfile(options.routing) : undefined;
+  if (options.routing !== undefined && !profile) {
+    onUnknownProfile?.(options.routing);
+  }
+
+  const profileProvider = profile?.kind === 'provider' ? profile.provider : undefined;
+  const provider = normalizeOpenRouterProviderRouting(
+    mergeOpenRouterProviderRouting(profileProvider, options.provider),
+  );
+
+  if (!provider) return undefined;
+  return { openrouter: { provider } };
 }
 
 /**
@@ -74,17 +167,19 @@ export function openrouterOptions(options: {
   route?: 'fallback' | string;
   /** Provider 偏好顺序 */
   providerOrder?: string[];
+  /** Provider routing 配置（camelCase，返回时转成 OpenRouter payload） */
+  provider?: OpenRouterProviderRouting;
   /**
    * Provider 排序策略（禁用负载均衡，按指定属性排序）
    * - 'price': 优先最低价格
    * - 'throughput': 优先最高吞吐量
    * - 'latency': 优先最低延迟
    */
-  providerSort?: 'price' | 'throughput' | 'latency';
+  providerSort?: OpenRouterProviderSort;
   /** 其他透传参数 */
   extra?: Record<string, unknown>;
 }) {
-  const { disableThinking, reasoningEffort, route, providerOrder, providerSort, extra } = options;
+  const { disableThinking, reasoningEffort, route, providerOrder, provider, providerSort, extra } = options;
 
   const reasoning = (() => {
     if (disableThinking) {
@@ -99,17 +194,23 @@ export function openrouterOptions(options: {
     return undefined;
   })();
 
-  // 构建 provider 配置
-  const providerConfig = {
-    ...(providerOrder && { order: providerOrder }),
-    ...(providerSort && { sort: providerSort }),
-  };
+  const providerConfig = normalizeOpenRouterProviderRouting(
+    mergeOpenRouterProviderRouting(
+      provider,
+      providerOrder || providerSort
+        ? {
+            ...(providerOrder ? { order: providerOrder } : {}),
+            ...(providerSort ? { sort: providerSort } : {}),
+          }
+        : undefined,
+    ),
+  );
 
   return {
     openrouter: {
       ...(reasoning && { reasoning }),
       ...(route && { route }),
-      ...(Object.keys(providerConfig).length > 0 && { provider: providerConfig }),
+      ...(providerConfig && { provider: providerConfig }),
       ...extra,
     },
   };

--- a/features/llm/types/model.types.spec.ts
+++ b/features/llm/types/model.types.spec.ts
@@ -129,6 +129,21 @@ describe('parseModelSpec', () => {
     expect(result.fallbackModels).toEqual([KNOWN_KEY_2]);
   });
 
+  it('should parse openrouter.routing as provider-namespaced options', () => {
+    const spec = 'openrouter:claude-sonnet-4.5?openrouter.routing=bedrock' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.provider).toBe('openrouter');
+    expect(result.openrouter).toEqual({ routing: 'bedrock' });
+    expect(result.vertex).toBeUndefined();
+  });
+
+  it('should ignore openrouter.routing on non-openrouter providers', () => {
+    const spec = 'google:gemini-2.5-flash?openrouter.routing=bedrock' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.provider).toBe('google');
+    expect(result.openrouter).toBeUndefined();
+  });
+
   it('should handle empty query string gracefully', () => {
     const spec = `${KNOWN_KEY}?` as LLMModelSpec;
     const result = parseModelSpec(spec);

--- a/features/llm/types/model.types.ts
+++ b/features/llm/types/model.types.ts
@@ -54,6 +54,41 @@ export type VertexRequestType = 'shared';
 /** 模块级单例，避免 `supportedTiers` 缺省时每次调用都分配新数组 */
 export const DEFAULT_SUPPORTED_TIERS: readonly VertexTier[] = ['standard'];
 
+/** OpenRouter provider 排序策略。 */
+export type OpenRouterProviderSort = 'price' | 'throughput' | 'latency';
+
+/** OpenRouter provider routing，框架侧使用 camelCase，adapter 负责转成 OpenRouter payload。 */
+export interface OpenRouterProviderRouting {
+  /** Provider slugs to try in order. */
+  order?: readonly string[];
+  /** Only allow these provider slugs. */
+  only?: readonly string[];
+  /** Skip these provider slugs. */
+  ignore?: readonly string[];
+  /** OpenRouter `allow_fallbacks`. */
+  allowFallbacks?: boolean;
+  /** OpenRouter `require_parameters`. */
+  requireParameters?: boolean;
+  /** Sort providers by a supported OpenRouter dimension. */
+  sort?: OpenRouterProviderSort;
+  /** Escape hatch for OpenRouter provider-routing fields not promoted by this framework yet. */
+  extra?: Record<string, unknown>;
+}
+
+/** OpenRouter-specific options parsed from model specs or accepted by call sites. */
+export interface OpenRouterModelOptions {
+  /** Named routing profile, resolved by the OpenRouter adapter. */
+  routing?: string;
+  /** Direct provider routing override. */
+  provider?: OpenRouterProviderRouting;
+}
+
+/** Vertex-specific options parsed from model specs. */
+export interface VertexModelOptions {
+  tier?: VertexTier;
+  requestType?: VertexRequestType;
+}
+
 /**
  * Model 配置接口
  */
@@ -585,6 +620,7 @@ export type LLMModelSpec = LLMModelKey | `${LLMModelKey}?${string}`;
  */
 export interface ParsedModelSpec {
   key: LLMModelKey;
+  provider: LLMProviderType;
   thinking: ThinkingEffortLevel | undefined;
   /** 最大重试次数（覆盖 AI_LLM_MAX_RETRIES） */
   maxRetries: number | undefined;
@@ -596,11 +632,19 @@ export interface ParsedModelSpec {
   tier: VertexTier | undefined;
   /** Vertex request type（仅 vertex / vertex-global + tier=flex/priority 时生效） */
   vertexRequestType: VertexRequestType | undefined;
+  /** Provider-namespaced Vertex options. */
+  vertex: VertexModelOptions | undefined;
+  /** Provider-namespaced OpenRouter options. */
+  openrouter: OpenRouterModelOptions | undefined;
 }
 
 const VALID_THINKING_EFFORTS = new Set<string>(['none', 'low', 'medium', 'high']);
 const VALID_VERTEX_TIERS = new Set<string>(['standard', 'flex', 'priority']);
 const VALID_VERTEX_REQUEST_TYPES = new Set<string>(['shared']);
+
+function parseProviderFromKey(key: LLMModelKey): LLMProviderType {
+  return key.slice(0, key.indexOf(':')) as LLMProviderType;
+}
 
 /**
  * 解析 LLMModelSpec 为 base key + 参数
@@ -615,17 +659,22 @@ const VALID_VERTEX_REQUEST_TYPES = new Set<string>(['shared']);
 export function parseModelSpec(spec: LLMModelSpec): ParsedModelSpec {
   const qIdx = spec.indexOf('?');
   if (qIdx === -1) {
+    const key = spec as LLMModelKey;
     return {
-      key: spec as LLMModelKey,
+      key,
+      provider: parseProviderFromKey(key),
       thinking: undefined,
       maxRetries: undefined,
       timeout: undefined,
       fallbackModels: [],
       tier: undefined,
       vertexRequestType: undefined,
+      vertex: undefined,
+      openrouter: undefined,
     };
   }
   const key = spec.slice(0, qIdx) as LLMModelKey;
+  const provider = parseProviderFromKey(key);
   const params = new URLSearchParams(spec.slice(qIdx + 1));
 
   // reason → thinking effort（无效值 warning + 忽略，不阻断）
@@ -678,29 +727,72 @@ export function parseModelSpec(spec: LLMModelSpec): ParsedModelSpec {
     }
   }
 
-  // tier → Vertex AI tier（无效值 warning + 忽略）
-  const tierRaw = params.get('tier');
+  // vertex.tier → Vertex AI tier. Legacy ?tier= remains supported for backward compatibility.
+  const tierNamespacedRaw = params.get('vertex.tier');
+  const tierLegacyRaw = params.get('tier');
+  if (tierLegacyRaw !== null) {
+    logger.warning`[parseModelSpec] "tier" is deprecated in "${spec}", use "vertex.tier"`;
+  }
+  if (tierNamespacedRaw !== null && tierLegacyRaw !== null && tierNamespacedRaw !== tierLegacyRaw) {
+    logger.warning`[parseModelSpec] Both "vertex.tier" and legacy "tier" are present in "${spec}", using "vertex.tier"`;
+  }
+  const tierRaw = tierNamespacedRaw ?? tierLegacyRaw;
   let tier: VertexTier | undefined;
   if (tierRaw !== null) {
-    if (VALID_VERTEX_TIERS.has(tierRaw)) {
+    if (provider !== 'vertex' && provider !== 'vertex-global' && tierNamespacedRaw !== null) {
+      logger.warning`[parseModelSpec] vertex.tier requested for non-vertex provider=${provider} in "${spec}", ignoring`;
+    } else if (VALID_VERTEX_TIERS.has(tierRaw)) {
       tier = tierRaw as VertexTier;
     } else {
       logger.warning`[parseModelSpec] Invalid tier "${tierRaw}" in "${spec}", ignoring. Valid: ${[...VALID_VERTEX_TIERS].join(', ')}`;
     }
   }
 
-  // vertexRequestType → Vertex AI request type header（无效值 warning + 忽略）
-  const vertexRequestTypeRaw = params.get('vertexRequestType');
+  // vertex.requestType → Vertex AI request type header. Legacy ?vertexRequestType= remains supported.
+  const vertexRequestTypeNamespacedRaw = params.get('vertex.requestType');
+  const vertexRequestTypeLegacyRaw = params.get('vertexRequestType');
+  if (vertexRequestTypeLegacyRaw !== null) {
+    logger.warning`[parseModelSpec] "vertexRequestType" is deprecated in "${spec}", use "vertex.requestType"`;
+  }
+  if (
+    vertexRequestTypeNamespacedRaw !== null &&
+    vertexRequestTypeLegacyRaw !== null &&
+    vertexRequestTypeNamespacedRaw !== vertexRequestTypeLegacyRaw
+  ) {
+    logger.warning`[parseModelSpec] Both "vertex.requestType" and legacy "vertexRequestType" are present in "${spec}", using "vertex.requestType"`;
+  }
+  const vertexRequestTypeRaw = vertexRequestTypeNamespacedRaw ?? vertexRequestTypeLegacyRaw;
   let vertexRequestType: VertexRequestType | undefined;
   if (vertexRequestTypeRaw !== null) {
-    if (VALID_VERTEX_REQUEST_TYPES.has(vertexRequestTypeRaw)) {
+    if (provider !== 'vertex' && provider !== 'vertex-global' && vertexRequestTypeNamespacedRaw !== null) {
+      logger.warning`[parseModelSpec] vertex.requestType requested for non-vertex provider=${provider} in "${spec}", ignoring`;
+    } else if (VALID_VERTEX_REQUEST_TYPES.has(vertexRequestTypeRaw)) {
       vertexRequestType = vertexRequestTypeRaw as VertexRequestType;
     } else {
       logger.warning`[parseModelSpec] Invalid vertexRequestType "${vertexRequestTypeRaw}" in "${spec}", ignoring. Valid: ${[...VALID_VERTEX_REQUEST_TYPES].join(', ')}`;
     }
   }
 
-  return { key, thinking, maxRetries, timeout, fallbackModels, tier, vertexRequestType };
+  // openrouter.routing → OpenRouter named routing profile.
+  const openrouterRoutingRaw = params.get('openrouter.routing');
+  let openrouter: OpenRouterModelOptions | undefined;
+  if (openrouterRoutingRaw !== null) {
+    if (provider === 'openrouter') {
+      openrouter = { routing: openrouterRoutingRaw };
+    } else {
+      logger.warning`[parseModelSpec] openrouter.routing requested for provider=${provider} in "${spec}", ignoring`;
+    }
+  }
+
+  const vertex =
+    tier !== undefined || vertexRequestType !== undefined
+      ? {
+          ...(tier !== undefined ? { tier } : {}),
+          ...(vertexRequestType !== undefined ? { requestType: vertexRequestType } : {}),
+        }
+      : undefined;
+
+  return { key, provider, thinking, maxRetries, timeout, fallbackModels, tier, vertexRequestType, vertex, openrouter };
 }
 
 /**

--- a/features/llm/types/request.types.ts
+++ b/features/llm/types/request.types.ts
@@ -7,7 +7,7 @@
  * 3. Provider 特有选项类型安全
  */
 
-import type { LLMModelKey } from './model.types';
+import type { LLMModelKey, OpenRouterProviderRouting } from './model.types';
 import type { z } from 'zod';
 
 // ==================== 消息类型 ====================
@@ -47,12 +47,16 @@ export interface LLMUsage {
 export interface LLMProviderOptionsRegistry {
   // OpenRouter 特有选项
   openrouter: {
+    /** Named routing profile */
+    routing?: string;
     /** 路由策略 */
     route?: 'fallback' | string;
     /** 模型转换 */
     transforms?: string[];
     /** Provider 偏好顺序 */
     providerOrder?: string[];
+    /** Provider routing options */
+    provider?: OpenRouterProviderRouting;
     /** 额外透传参数 */
     extra?: Record<string, unknown>;
   };


### PR DESCRIPTION
## Summary

- Add provider-namespaced LLM model spec options for Vertex and OpenRouter.
- Add OpenRouter routing profiles with a built-in `bedrock` profile that pins `amazon-bedrock` and disables fallbacks.
- Expose OpenRouter routing profile registration through the public LLM barrel.
- Cover model-spec parsing, OpenRouter provider payload normalization, call-level overrides, and `prepareStep.llm.openrouter` behavior.

## Validation

- `tsc --noEmit`
- `eslint . --fix`
- `bun test`