### PR TITLE
fix workspace-independent source path tests

### DIFF
--- a/features/llm/clients/provenance-runtime-context.spec.ts
+++ b/features/llm/clients/provenance-runtime-context.spec.ts
@@ -96,8 +96,14 @@ describe('LLM provenance runtime context', () => {
   it('keeps LLM client provenance formatting independent from tracing span helpers', () => {
     const autoClient = readFileSync(join(import.meta.dir, 'auto.client.ts'), 'utf8');
     const llmClass = readFileSync(join(import.meta.dir, 'llm.class.ts'), 'utf8');
-    const provenanceContext = readFileSync(join(process.cwd(), 'nest/src/trace/provenance-context.ts'), 'utf8');
-    const provenanceFormat = readFileSync(join(process.cwd(), 'nest/src/trace/provenance-format.ts'), 'utf8');
+    const provenanceContext = readFileSync(
+      join(import.meta.dir, '../../../nest/src/trace/provenance-context.ts'),
+      'utf8',
+    );
+    const provenanceFormat = readFileSync(
+      join(import.meta.dir, '../../../nest/src/trace/provenance-format.ts'),
+      'utf8',
+    );
 
     expect(autoClient).not.toContain('@app/nest/trace/provenance-tags');
     expect(llmClass).not.toContain('@app/nest/trace/provenance-tags');

--- a/nest/src/exceptions/any-exception.filter.spec.ts
+++ b/nest/src/exceptions/any-exception.filter.spec.ts
@@ -673,7 +673,7 @@ describe('toErrorDescriptor', () => {
   });
 
   it('error-descriptor does not import optional throttler at module scope', () => {
-    const source = readFileSync(join(process.cwd(), 'nest/src/exceptions/error-descriptor.ts'), 'utf8');
+    const source = readFileSync(join(import.meta.dir, 'error-descriptor.ts'), 'utf8');
 
     expect(source).not.toContain('@nestjs/throttler');
   });


### PR DESCRIPTION
## What changed

Two source-inspection tests now resolve files relative to their own test module with import.meta.dir instead of assuming process.cwd is the nestjs-libs repository root.

## Why

nestjs-libs is consumed as a Bun workspace/submodule. Running bun test from a consumer root legitimately changes process.cwd, causing these tests to fail even though the source contracts are correct. Tests in a shared library must be independent of the caller working directory.

## Validation

- TypeScript typecheck passed
- ESLint passed
- 508 libs tests passed from the libs checkout
- 627 workspace tests passed when launched from unee-thirdparty-service root
- unee-thirdparty-service complete check passed with zero lint warnings