### PR TITLE
Add generic provenance baggage carrier

### DIFF
--- a/features/llm/clients/provenance-runtime-context.spec.ts
+++ b/features/llm/clients/provenance-runtime-context.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 
+import { contextWithProvenanceBaggage, readProvenanceBaggage } from '@app/nest/trace/provenance-baggage';
 import { setProvenanceTags } from '@app/nest/trace/provenance-tags';
 import { RequestContext } from '@app/nest/trace/request-context';
 
@@ -34,6 +35,26 @@ describe('LLM provenance runtime context', () => {
     const callerContext = { parentObservationId: 'parent-1' };
 
     expect(mergeProvenanceRuntimeContext(callerContext)).toBe(callerContext);
+  });
+
+  it('projects propagated provenance into AI SDK v7 runtime context', () => {
+    const propagatedContext = contextWithProvenanceBaggage({
+      'fixture.origin': 'synthetic',
+      'fixture.source': 'eval',
+    });
+
+    const normalizedBaggage = readProvenanceBaggage(propagatedContext);
+    const runtimeContext = RequestContext.run({}, () => {
+      // Boundary acceptance is explicit: normalization alone does not establish source trust.
+      setProvenanceTags(normalizedBaggage);
+      return mergeProvenanceRuntimeContext({
+        tags: ['task:reply'],
+      });
+    });
+
+    expect(runtimeContext).toEqual({
+      tags: ['task:reply', 'fixture.origin:synthetic', 'fixture.source:eval'],
+    });
   });
 
   it('keeps LLM client provenance formatting independent from tracing span helpers', () => {

--- a/nest/src/trace/index.ts
+++ b/nest/src/trace/index.ts
@@ -1,4 +1,5 @@
 export * from './interface';
+export * from './provenance-baggage';
 export * from './provenance-tags';
 export * from './request-context';
 export * from './trace.decorator';

--- a/nest/src/trace/provenance-baggage.spec.ts
+++ b/nest/src/trace/provenance-baggage.spec.ts
@@ -2,10 +2,12 @@ import { contextWithProvenanceBaggage, PROVENANCE_BAGGAGE_KEY, readProvenanceBag
 import { getProvenanceTags, setProvenanceTags } from './provenance-tags';
 import { RequestContext } from './request-context';
 
+import { configure, reset } from '@logtape/logtape';
 import { defaultTextMapGetter, defaultTextMapSetter, propagation, ROOT_CONTEXT } from '@opentelemetry/api';
 import { W3CBaggagePropagator } from '@opentelemetry/core';
 import { describe, expect, it } from 'bun:test';
 
+import type { LogRecord } from '@logtape/logtape';
 import type { Context } from '@opentelemetry/api';
 
 function contextWithBaggage(entries: Record<string, { value: string }>): Context {
@@ -99,6 +101,35 @@ describe('provenance baggage', () => {
       'fixture.scenario': 'case-1',
       'fixture.source': 'new',
     });
+  });
+
+  it('warns when the tag limit drops additional outbound provenance', async () => {
+    const records: LogRecord[] = [];
+    await configure({
+      reset: true,
+      sinks: {
+        recorder: (record) => records.push(record),
+      },
+      loggers: [
+        { category: [], sinks: ['recorder'], lowestLevel: 'warning' },
+        { category: ['logtape', 'meta'], sinks: [] },
+      ],
+    });
+
+    try {
+      const fullContext = contextWithProvenanceBaggage(
+        Object.fromEntries(Array.from({ length: 16 }, (_, index) => [`upstream.tag_${index}`, String(index)])),
+      );
+
+      const propagatedContext = contextWithProvenanceBaggage({ 'local.source': 'service' }, fullContext);
+
+      expect(readProvenanceBaggage(propagatedContext)['local.source']).toBeUndefined();
+      expect(records.map((record) => record.message.map(String).join(''))).toContain(
+        'Dropped 1 invalid or excess provenance tag(s)',
+      );
+    } finally {
+      await reset();
+    }
   });
 
   it('removes an empty provenance entry without dropping unrelated baggage', () => {

--- a/nest/src/trace/provenance-baggage.spec.ts
+++ b/nest/src/trace/provenance-baggage.spec.ts
@@ -1,0 +1,143 @@
+import { contextWithProvenanceBaggage, PROVENANCE_BAGGAGE_KEY, readProvenanceBaggage } from './provenance-baggage';
+import { getProvenanceTags, setProvenanceTags } from './provenance-tags';
+import { RequestContext } from './request-context';
+
+import { defaultTextMapGetter, defaultTextMapSetter, propagation, ROOT_CONTEXT } from '@opentelemetry/api';
+import { W3CBaggagePropagator } from '@opentelemetry/core';
+import { describe, expect, it } from 'bun:test';
+
+import type { Context } from '@opentelemetry/api';
+
+function contextWithBaggage(entries: Record<string, { value: string }>): Context {
+  return propagation.setBaggage(ROOT_CONTEXT, propagation.createBaggage(entries));
+}
+
+describe('provenance baggage', () => {
+  it('normalizes provenance and preserves unrelated baggage entries', () => {
+    const baseContext = contextWithBaggage({
+      'vendor.trace': { value: 'keep' },
+    });
+
+    const propagatedContext = contextWithProvenanceBaggage(
+      {
+        'fixture.source': ' eval ',
+        'fixture.attempt': 2,
+        'fixture.synthetic': true,
+      },
+      baseContext,
+    );
+
+    expect(propagation.getBaggage(propagatedContext)?.getEntry('vendor.trace')).toEqual({ value: 'keep' });
+    expect(readProvenanceBaggage(propagatedContext)).toEqual({
+      'fixture.attempt': '2',
+      'fixture.source': 'eval',
+      'fixture.synthetic': 'true',
+    });
+    expect(propagation.getBaggage(propagatedContext)?.getEntry(PROVENANCE_BAGGAGE_KEY)?.value).toBe(
+      '{"fixture.attempt":"2","fixture.source":"eval","fixture.synthetic":"true"}',
+    );
+  });
+
+  it('uses the existing sanitizer for untrusted outbound tags', () => {
+    const propagatedContext = contextWithProvenanceBaggage({
+      'fixture.source': 'eval',
+      'fixture.attempt': 2,
+      'fixture.api_key': 'must-not-propagate',
+      'bad key': 'invalid',
+      empty: ' ',
+      unsupported: { nested: true },
+    });
+
+    expect(readProvenanceBaggage(propagatedContext)).toEqual({
+      'fixture.attempt': '2',
+      'fixture.source': 'eval',
+    });
+  });
+
+  it('survives a real W3C baggage inject and extract round trip', () => {
+    const propagatedContext = contextWithProvenanceBaggage({
+      'fixture.origin': 'synthetic',
+      'fixture.source': 'eval',
+    });
+    const carrier: Record<string, string> = {};
+    const propagator = new W3CBaggagePropagator();
+
+    propagator.inject(propagatedContext, carrier, defaultTextMapSetter);
+    const extractedContext = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
+
+    expect(carrier.baggage).toContain('provenance.tags=');
+    expect(readProvenanceBaggage(extractedContext)).toEqual({
+      'fixture.origin': 'synthetic',
+      'fixture.source': 'eval',
+    });
+  });
+
+  it('rejects malformed, non-object, and oversized inbound values without throwing', () => {
+    const invalidValues = ['{', '[]', '"text"', '7', 'x'.repeat(4_097)];
+
+    for (const value of invalidValues) {
+      const tags = readProvenanceBaggage(
+        contextWithBaggage({
+          [PROVENANCE_BAGGAGE_KEY]: { value },
+        }),
+      );
+
+      expect(tags).toEqual({});
+      expect(Object.isFrozen(tags)).toBe(true);
+    }
+  });
+
+  it('lets current provenance override an older propagated value', () => {
+    const baseContext = contextWithProvenanceBaggage({
+      'fixture.source': 'old',
+      'fixture.scenario': 'case-1',
+    });
+
+    const propagatedContext = contextWithProvenanceBaggage({ 'fixture.source': 'new' }, baseContext);
+
+    expect(readProvenanceBaggage(propagatedContext)).toEqual({
+      'fixture.scenario': 'case-1',
+      'fixture.source': 'new',
+    });
+  });
+
+  it('removes an empty provenance entry without dropping unrelated baggage', () => {
+    const baseContext = contextWithBaggage({
+      'vendor.trace': { value: 'keep' },
+      [PROVENANCE_BAGGAGE_KEY]: { value: '{' },
+    });
+
+    const propagatedContext = contextWithProvenanceBaggage({ 'bad key': 'invalid' }, baseContext);
+    const baggage = propagation.getBaggage(propagatedContext);
+
+    expect(baggage?.getEntry(PROVENANCE_BAGGAGE_KEY)).toBeUndefined();
+    expect(baggage?.getEntry('vendor.trace')).toEqual({ value: 'keep' });
+  });
+
+  it('does not create a member that the W3C propagator would drop for encoded size', () => {
+    const tags = Object.fromEntries(
+      Array.from({ length: 16 }, (_, index) => [`fixture.tag_${index}`, '\\'.repeat(128)]),
+    );
+
+    const propagatedContext = contextWithProvenanceBaggage(tags);
+
+    expect(propagation.getBaggage(propagatedContext)?.getEntry(PROVENANCE_BAGGAGE_KEY)).toBeUndefined();
+  });
+
+  it('normalizes inbound baggage without trusting it into request-local provenance', () => {
+    const propagatedContext = contextWithProvenanceBaggage({
+      'fixture.origin': 'synthetic',
+      'fixture.source': 'eval',
+    });
+
+    RequestContext.run({}, () => {
+      setProvenanceTags({ 'fixture.source': 'local' });
+
+      expect(readProvenanceBaggage(propagatedContext)).toEqual({
+        'fixture.origin': 'synthetic',
+        'fixture.source': 'eval',
+      });
+      expect(getProvenanceTags()).toEqual({ 'fixture.source': 'local' });
+    });
+  });
+});

--- a/nest/src/trace/provenance-baggage.spec.ts
+++ b/nest/src/trace/provenance-baggage.spec.ts
@@ -103,6 +103,18 @@ describe('provenance baggage', () => {
     });
   });
 
+  it('does not let invalid local tags erase valid propagated provenance', () => {
+    const baseContext = contextWithProvenanceBaggage({
+      'fixture.source': 'eval',
+    });
+
+    const propagatedContext = contextWithProvenanceBaggage({ 'fixture.source': ' ' }, baseContext);
+
+    expect(readProvenanceBaggage(propagatedContext)).toEqual({
+      'fixture.source': 'eval',
+    });
+  });
+
   it('warns when the tag limit drops additional outbound provenance', async () => {
     const records: LogRecord[] = [];
     await configure({

--- a/nest/src/trace/provenance-baggage.ts
+++ b/nest/src/trace/provenance-baggage.ts
@@ -1,0 +1,63 @@
+import { sanitizeProvenanceTags, sortedProvenanceEntries } from './provenance-format';
+import { getProvenanceTags } from './provenance-tags';
+
+import { context, propagation } from '@opentelemetry/api';
+
+import type { ProvenanceTags } from './provenance-format';
+import type { Context } from '@opentelemetry/api';
+
+export const PROVENANCE_BAGGAGE_KEY = 'provenance.tags';
+
+const MAX_PROVENANCE_BAGGAGE_VALUE_LENGTH = 4_096;
+const MAX_W3C_BAGGAGE_MEMBER_LENGTH = 4_096;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function emptyProvenanceTags(): ProvenanceTags {
+  return sanitizeProvenanceTags(undefined);
+}
+
+function fitsW3cBaggageMember(value: string): boolean {
+  const encodedMember = `${encodeURIComponent(PROVENANCE_BAGGAGE_KEY)}=${encodeURIComponent(value)}`;
+  return encodedMember.length <= MAX_W3C_BAGGAGE_MEMBER_LENGTH;
+}
+
+/** Normalizes transport data only; callers must establish trust before storing these tags in request context. */
+export function readProvenanceBaggage(activeContext: Context = context.active()): ProvenanceTags {
+  const value = propagation.getBaggage(activeContext)?.getEntry(PROVENANCE_BAGGAGE_KEY)?.value;
+  if (!value || value.length > MAX_PROVENANCE_BAGGAGE_VALUE_LENGTH) {
+    return emptyProvenanceTags();
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? sanitizeProvenanceTags(parsed) : emptyProvenanceTags();
+  } catch {
+    return emptyProvenanceTags();
+  }
+}
+
+export function contextWithProvenanceBaggage(
+  tags: Record<string, unknown> = getProvenanceTags(),
+  activeContext: Context = context.active(),
+): Context {
+  const baggage = propagation.getBaggage(activeContext);
+  const merged = sanitizeProvenanceTags({
+    ...readProvenanceBaggage(activeContext),
+    ...tags,
+  });
+
+  if (Object.keys(merged).length === 0) {
+    return baggage ? propagation.setBaggage(activeContext, baggage.removeEntry(PROVENANCE_BAGGAGE_KEY)) : activeContext;
+  }
+
+  const value = JSON.stringify(Object.fromEntries(sortedProvenanceEntries(merged)));
+  if (value.length > MAX_PROVENANCE_BAGGAGE_VALUE_LENGTH || !fitsW3cBaggageMember(value)) {
+    return baggage ? propagation.setBaggage(activeContext, baggage.removeEntry(PROVENANCE_BAGGAGE_KEY)) : activeContext;
+  }
+
+  const nextBaggage = (baggage ?? propagation.createBaggage()).setEntry(PROVENANCE_BAGGAGE_KEY, { value });
+  return propagation.setBaggage(activeContext, nextBaggage);
+}

--- a/nest/src/trace/provenance-baggage.ts
+++ b/nest/src/trace/provenance-baggage.ts
@@ -44,10 +44,13 @@ export function contextWithProvenanceBaggage(
   activeContext: Context = context.active(),
 ): Context {
   const baggage = propagation.getBaggage(activeContext);
-  const merged = sanitizeProvenanceTags({
-    ...readProvenanceBaggage(activeContext),
-    ...tags,
-  });
+  const merged = sanitizeProvenanceTags(
+    {
+      ...readProvenanceBaggage(activeContext),
+      ...tags,
+    },
+    { warn: true },
+  );
 
   if (Object.keys(merged).length === 0) {
     return baggage ? propagation.setBaggage(activeContext, baggage.removeEntry(PROVENANCE_BAGGAGE_KEY)) : activeContext;

--- a/nest/src/trace/provenance-baggage.ts
+++ b/nest/src/trace/provenance-baggage.ts
@@ -44,10 +44,11 @@ export function contextWithProvenanceBaggage(
   activeContext: Context = context.active(),
 ): Context {
   const baggage = propagation.getBaggage(activeContext);
+  const localTags = sanitizeProvenanceTags(tags, { warn: true });
   const merged = sanitizeProvenanceTags(
     {
       ...readProvenanceBaggage(activeContext),
-      ...tags,
+      ...localTags,
     },
     { warn: true },
   );

--- a/nest/src/trace/provenance-format.ts
+++ b/nest/src/trace/provenance-format.ts
@@ -43,7 +43,7 @@ function normalizeValue(value: unknown): string | undefined {
 
 function warnDropped(dropped: number): void {
   if (dropped > 0) {
-    logger.warning`Dropped ${dropped} invalid provenance tag(s)`;
+    logger.warning`Dropped ${dropped} invalid or excess provenance tag(s)`;
   }
 }
 


### PR DESCRIPTION
## Goal

Close the remaining shared-libs gap behind Calo's fork-only sandbox baggage flow without moving Calo-specific headers or AI SDK v6 telemetry semantics into upstream.

## Design

- Add a provider-neutral `provenance.tags` W3C Baggage carrier backed by the existing provenance sanitizer.
- Preserve unrelated baggage and merge current local provenance over older propagated values.
- Reject malformed, non-object, sensitive/invalid, raw-oversized, and W3C-encoded-oversized values without throwing.
- Keep trust explicit: decoding only normalizes untrusted transport data; consumers must accept it after their auth/service boundary before calling `setProvenanceTags`.
- Prove explicitly accepted tags reach the existing AI SDK v7 `runtimeContext.tags` projection.

## Fork Convergence

- OTLP export, trace IDs, redaction, recursive payload normalization, gRPC/Oops handling, model registrations, and Vertex request normalization already exist on upstream in equivalent or stronger form.
- Calo `sandbox-*` header mapping remains a Calo boundary concern.
- AI SDK v6 `maxSteps`, root tool fields, and legacy telemetry aliases remain intentionally unsupported.

## Contract Impact

Additive shared API only. No REST, GraphQL, gRPC, provider, Oops, database, consumer, lockfile, or tracked docs change.

## Verification

- `bun test`: 556 pass / 0 fail
- Focused provenance + AI v7 runtime-context tests: 19 pass / 0 fail
- `bun run typecheck`
- `bun run lint`
- `bun run check:dep-identity`
- Real `W3CBaggagePropagator` inject/extract round-trip
- `git diff --cached --check`

## Deferred Consumer Work

Calo must map authenticated `sandbox-*` inputs to namespaced provenance and explicitly accept normalized inbound baggage during the consumer migration. Deployment compatibility with the legacy `sandbox.tags` carrier will be handled there.
