### PR TITLE
Fix hybrid microservice lifecycle ownership

### DIFF
--- a/nest/src/boot/bootstrap.spec.ts
+++ b/nest/src/boot/bootstrap.spec.ts
@@ -1,5 +1,5 @@
-import { ValidationPipe } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
+import { Module, ValidationPipe } from '@nestjs/common';
+import { NestFactory, Reflector } from '@nestjs/core';
 
 import { GrpcExceptionFilter } from '@app/nest/exceptions/grpc-exception.filter';
 import { GrpcServiceTokenGuard } from '@app/nest/guards';
@@ -10,10 +10,14 @@ import {
   assertGrpcServiceTokenConfiguredForMode,
   configureGrpcMicroserviceBoundary,
   hasGrpcMicroserviceConfigured,
+  resolveGrpcHybridAppOptions,
   resolveGrpcProvider,
 } from './bootstrap';
 
 import { afterEach, describe, expect, it } from 'bun:test';
+
+import type { OnModuleInit } from '@nestjs/common';
+import type { CustomTransportStrategy } from '@nestjs/microservices';
 
 const ORIGINAL_TOKEN = process.env.GRPC_SERVICE_TOKEN;
 const GRPC_BOOTSTRAP_OPTIONS = {
@@ -48,6 +52,25 @@ class GrpcBoundaryRecorder {
     this.pipes.push(...pipes);
     return this;
   }
+}
+
+let sharedInitHookCalls = 0;
+
+class SharedLifecycleProbe implements OnModuleInit {
+  onModuleInit(): void {
+    sharedInitHookCalls += 1;
+  }
+}
+
+@Module({ providers: [SharedLifecycleProbe] })
+class HybridLifecycleTestModule {}
+
+class NoopTransportStrategy implements CustomTransportStrategy {
+  listen(callback: () => void): void {
+    callback();
+  }
+
+  close(): void {}
 }
 
 function restoreToken() {
@@ -98,6 +121,23 @@ describe('assertGrpcServiceTokenConfiguredForMode', () => {
     expect(target.interceptors).toHaveLength(2);
     expect(target.interceptors[0]).toBeInstanceOf(GraphqlAwareClassSerializerInterceptor);
     expect(target.interceptors[1]).toBeInstanceOf(LoggerInterceptor);
+  });
+
+  it('initializes shared providers once when an api app attaches a grpc microservice', async () => {
+    sharedInitHookCalls = 0;
+    const app = await NestFactory.create(HybridLifecycleTestModule, { logger: false });
+    app.connectMicroservice({ strategy: new NoopTransportStrategy() }, resolveGrpcHybridAppOptions('api'));
+
+    try {
+      await app.startAllMicroservices();
+      await app.init();
+
+      expect(resolveGrpcHybridAppOptions('api')).toEqual({ inheritAppConfig: false });
+      expect(resolveGrpcHybridAppOptions('grpc')).toEqual({ inheritAppConfig: true });
+      expect(sharedInitHookCalls).toBe(1);
+    } finally {
+      await app.close();
+    }
   });
 
   it('does not require GRPC_SERVICE_TOKEN outside grpc mode', () => {

--- a/nest/src/boot/bootstrap.ts
+++ b/nest/src/boot/bootstrap.ts
@@ -114,6 +114,15 @@ export function resolveGrpcProvider(options?: Pick<BootstrapOptions, 'grpc' | 'g
   );
 }
 
+/**
+ * Hybrid microservices share the root application's DI container. Their listener
+ * registration must not defer initialization, otherwise the microservice and the
+ * root HTTP app each run the same provider lifecycle hooks.
+ */
+export function resolveGrpcHybridAppOptions(mode: BootstrapMode): { inheritAppConfig: boolean } {
+  return { inheritAppConfig: mode === 'grpc' };
+}
+
 function createGlobalValidationPipe(): ValidationPipe {
   return new ValidationPipe(GLOBAL_VALIDATION_PIPE_OPTIONS);
 }
@@ -395,7 +404,7 @@ export async function bootstrap(
   if (options?.grpc) {
     grpcPort = isGrpc ? (options.grpc.port ?? SysEnv.GRPC_PORT) : SysEnv.GRPC_PORT;
     const enableReflection = options.grpc.reflection !== false;
-    const inheritAppConfig = isGrpc;
+    const hybridAppOptions = resolveGrpcHybridAppOptions(mode);
 
     const grpcMs = app.connectMicroservice<MicroserviceOptions>(
       {
@@ -416,9 +425,9 @@ export async function bootstrap(
             : undefined,
         },
       },
-      { inheritAppConfig, deferInitialization: !inheritAppConfig },
+      hybridAppOptions,
     );
-    if (!inheritAppConfig) {
+    if (!hybridAppOptions.inheritAppConfig) {
       configureGrpcMicroserviceBoundary(grpcMs, app.get(Reflector), grpcProvider);
     }
     setGrpcMicroserviceRef(grpcMs, grpcPort);


### PR DESCRIPTION
## What changed

- Keep hybrid gRPC microservices on an independent application config when attached to an API app.
- Stop deferring initialization of the shared Nest container.
- Add a lifecycle regression test proving a shared provider receives exactly one `onModuleInit` call across microservice startup and root app initialization.

## Root cause

`deferInitialization: true` makes the attached microservice run module init hooks when `startAllMicroservices()` calls `listen()`. The root HTTP app later runs the same hooks again during `listen()` / `init()` because both applications share one DI container. In `unee-server`, this caused `BullExplorer` to call `queue.process(__default__)` twice and Bull aborted startup with `Cannot define the same handler twice __default__`.

## Boundary and impact

The root application remains the single lifecycle owner for shared providers. API-hosted gRPC still uses `inheritAppConfig: false` and receives its explicit gRPC filters, guard, interceptors, and pipe. Pure gRPC mode still inherits the root app config.

## Validation

- `bun test` — 559 pass, 0 fail
- `bun run typecheck`
- `bun run lint`
- Lifecycle regression: API app + attached no-op microservice initializes a shared provider exactly once
