### PR TITLE
feat(llm): add AWS Bedrock as first-class provider

### DIFF
--- a/env/src/configure.ts
+++ b/env/src/configure.ts
@@ -218,7 +218,7 @@ export class AbstractEnvironmentVariables implements HostSetVariables {
   @IsString() @IsOptional() AI_OPENAI_API_KEY?: string;
   /** AWS Bedrock API key（Bearer 认证；未设置时由 provider 回落 AWS_BEARER_TOKEN_BEDROCK 或 SigV4 静态凭证 AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY） */
   @IsString() @IsOptional() AI_BEDROCK_API_KEY?: string;
-  /** AWS Bedrock region（默认 us-east-1；本项目验证区域为 us-east-2，`us.*` inference profile 需美国区域端点） */
+  /** AWS Bedrock region（优先级：AI_BEDROCK_REGION > AWS_REGION > 默认 us-east-1；本项目验证区域为 us-east-2，`us.*` inference profile 需美国区域端点） */
   @IsString() @IsOptional() AI_BEDROCK_REGION?: string;
   @IsString() @IsOptional() AI_JINA_API_KEY?: string;
   @IsString() @IsOptional() AI_VOYAGE_API_KEY?: string;

--- a/env/src/configure.ts
+++ b/env/src/configure.ts
@@ -216,6 +216,10 @@ export class AbstractEnvironmentVariables implements HostSetVariables {
   /** Vertex AI location；Priority/Flex PayGo 文档要求使用 global */
   @IsString() @IsOptional() GOOGLE_VERTEX_LOCATION?: string;
   @IsString() @IsOptional() AI_OPENAI_API_KEY?: string;
+  /** AWS Bedrock API key（Bearer 认证；未设置时由 provider 回落 AWS_BEARER_TOKEN_BEDROCK 或 SigV4 静态凭证 AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY） */
+  @IsString() @IsOptional() AI_BEDROCK_API_KEY?: string;
+  /** AWS Bedrock region（默认 us-east-1；本项目验证区域为 us-east-2，`us.*` inference profile 需美国区域端点） */
+  @IsString() @IsOptional() AI_BEDROCK_REGION?: string;
   @IsString() @IsOptional() AI_JINA_API_KEY?: string;
   @IsString() @IsOptional() AI_VOYAGE_API_KEY?: string;
   /** 默认 LLM 模型，当指定模型不存在时作为 fallback（仅生产环境）。值须为已注册的 LLMModelKey（如 'openrouter:gemini-2.5-flash'） */

--- a/features/llm/clients/auto.client.ts
+++ b/features/llm/clients/auto.client.ts
@@ -26,13 +26,30 @@
 import { Oops } from '@app/nest/exceptions/oops';
 
 import { getModel } from '../types/model.types';
-import { google, openrouter, vertex, vertexGlobal } from './llm.clients';
+import { bedrockThinkingOptions } from './bedrock.client';
+import { bedrock, google, openrouter, vertex, vertexGlobal } from './llm.clients';
 
 import '@app/nest/exceptions/oops-factories';
+
+import { getAppLogger } from '@app/utils/app-logger';
 
 import type { LLMModelKey, LLMModelSpec, LLMProviderType } from '../types/model.types';
 import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import type { LanguageModel } from 'ai';
+
+const autoOptsLogger = getAppLogger('features', 'LLM', 'autoOpts');
+
+/**
+ * autoOpts 的 Bedrock 分支需要 modelId 判断 reasoning 配置形式（budget vs effort）。
+ * 裸 provider 名（'bedrock'）无法推断家族，warn + 返回空 options。
+ */
+function resolveBedrockModelId(key: LLMModelKey | string): string | undefined {
+  if (!key.includes(':')) {
+    autoOptsLogger.warning`[autoOpts] bare provider name "${key}" cannot infer Bedrock model family; pass a full model key (e.g. bedrock:claude-haiku-4.5). Returning empty options`;
+    return undefined;
+  }
+  return getModel(key as LLMModelSpec).modelId;
+}
 
 // ============================================================================
 // 自动路由客户端
@@ -63,6 +80,8 @@ export function model(key: LLMModelSpec, modelIdSuffix?: string): LanguageModel 
       return vertex(modelId);
     case 'vertex-global':
       return vertexGlobal(modelId);
+    case 'bedrock':
+      return bedrock(modelId);
     default:
       throw Oops.Panic.Config(`Unknown provider: ${provider as string} for model: ${key}`);
   }
@@ -85,7 +104,7 @@ export function model(key: LLMModelSpec, modelIdSuffix?: string): LanguageModel 
  */
 export function parseProvider(key: string): LLMProviderType {
   // 支持直接传 provider 名（如 'openrouter'）
-  const validProviders: LLMProviderType[] = ['openrouter', 'google', 'vertex', 'vertex-global'];
+  const validProviders: LLMProviderType[] = ['openrouter', 'google', 'vertex', 'vertex-global', 'bedrock'];
   if (validProviders.includes(key as LLMProviderType)) {
     return key as LLMProviderType;
   }
@@ -138,6 +157,11 @@ export const autoOpts = {
       case 'vertex': // Vertex 使用与 Google 相同的 providerOptions 格式
       case 'vertex-global':
         return { google: { thinkingConfig: { thinkingBudget: 0 } } };
+      case 'bedrock': {
+        // Bedrock reasoningConfig 按模型家族区分；不支持的家族返回空 options
+        const modelId = resolveBedrockModelId(key);
+        return modelId ? bedrockThinkingOptions(modelId, 'none') : {};
+      }
       default:
         return {};
     }
@@ -157,6 +181,11 @@ export const autoOpts = {
       case 'vertex': // Vertex 使用与 Google 相同的 providerOptions 格式
       case 'vertex-global':
         return { google: { thinkingConfig: { thinkingBudget: budgetMap[effort] } } };
+      case 'bedrock': {
+        // anthropic 家族 → budgetTokens；nova 2 家族 → maxReasoningEffort；其他 → warn + 空
+        const modelId = resolveBedrockModelId(key);
+        return modelId ? bedrockThinkingOptions(modelId, effort) : {};
+      }
       default:
         return {};
     }

--- a/features/llm/clients/bedrock.client.spec.ts
+++ b/features/llm/clients/bedrock.client.spec.ts
@@ -114,12 +114,6 @@ describe('autoOpts bedrock branch', () => {
     });
   });
 
-  it('thinking maps to adaptive for the registered opus-4.7 key', () => {
-    expect(autoOpts.thinking('bedrock:claude-opus-4.7', 'low')).toEqual({
-      bedrock: { reasoningConfig: { type: 'adaptive', maxReasoningEffort: 'low' } },
-    });
-  });
-
   it('M10: thinking on unsupported family returns empty options', () => {
     expect(autoOpts.thinking('bedrock:kimi-k2.5', 'low')).toEqual({});
   });

--- a/features/llm/clients/bedrock.client.spec.ts
+++ b/features/llm/clients/bedrock.client.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * AWS Bedrock provider options helpers 测试
+ *
+ * 覆盖 spec 的 M7-M10：reasoningConfig 按模型家族映射
+ * （anthropic → budgetTokens，nova 2 → maxReasoningEffort，其他 → warn + 空）。
+ */
+
+import { autoOpts } from './auto.client';
+import { bedrockServiceTierOptions, bedrockThinkingOptions, inferBedrockReasoningFamily } from './bedrock.client';
+
+import { describe, expect, it } from 'bun:test';
+
+describe('inferBedrockReasoningFamily', () => {
+  it('should detect anthropic family incl. cross-region/global profile prefixes', () => {
+    expect(inferBedrockReasoningFamily('us.anthropic.claude-sonnet-4-5-20250929-v1:0')).toBe('anthropic');
+    expect(inferBedrockReasoningFamily('global.anthropic.claude-haiku-4-5-20251001-v1:0')).toBe('anthropic');
+    expect(inferBedrockReasoningFamily('anthropic.claude-opus-4-6-v1')).toBe('anthropic');
+  });
+
+  it('should detect amazon nova 2 family', () => {
+    expect(inferBedrockReasoningFamily('us.amazon.nova-2-lite-v1:0')).toBe('amazon-nova');
+    expect(inferBedrockReasoningFamily('amazon.nova-2-lite-v1:0')).toBe('amazon-nova');
+  });
+
+  it('should treat nova 1 and other model families as other', () => {
+    expect(inferBedrockReasoningFamily('us.amazon.nova-pro-v1:0')).toBe('other');
+    expect(inferBedrockReasoningFamily('us.amazon.nova-lite-v1:0')).toBe('other');
+    expect(inferBedrockReasoningFamily('moonshotai.kimi-k2.5')).toBe('other');
+    expect(inferBedrockReasoningFamily('moonshot.kimi-k2-thinking')).toBe('other');
+    expect(inferBedrockReasoningFamily('deepseek.v3.2')).toBe('other');
+    expect(inferBedrockReasoningFamily('minimax.minimax-m2.5')).toBe('other');
+  });
+});
+
+describe('bedrockThinkingOptions', () => {
+  it('M7: none on reasoning-capable families disables reasoning', () => {
+    expect(bedrockThinkingOptions('us.anthropic.claude-sonnet-4-5-20250929-v1:0', 'none')).toEqual({
+      bedrock: { reasoningConfig: { type: 'disabled' } },
+    });
+    expect(bedrockThinkingOptions('us.amazon.nova-2-lite-v1:0', 'none')).toEqual({
+      bedrock: { reasoningConfig: { type: 'disabled' } },
+    });
+  });
+
+  it('M8: effort maps to budgetTokens for anthropic models', () => {
+    expect(bedrockThinkingOptions('us.anthropic.claude-sonnet-4-5-20250929-v1:0', 'low')).toEqual({
+      bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: 1024 } },
+    });
+    expect(bedrockThinkingOptions('us.anthropic.claude-opus-4-6-v1', 'medium')).toEqual({
+      bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: 4096 } },
+    });
+    expect(bedrockThinkingOptions('us.anthropic.claude-haiku-4-5-20251001-v1:0', 'high')).toEqual({
+      bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: 8192 } },
+    });
+  });
+
+  it('M9: effort maps to maxReasoningEffort for nova 2 models', () => {
+    expect(bedrockThinkingOptions('us.amazon.nova-2-lite-v1:0', 'medium')).toEqual({
+      bedrock: { reasoningConfig: { type: 'enabled', maxReasoningEffort: 'medium' } },
+    });
+  });
+
+  it('M10: effort on unsupported family is dropped with warning', () => {
+    expect(bedrockThinkingOptions('moonshotai.kimi-k2.5', 'low')).toEqual({});
+    expect(bedrockThinkingOptions('deepseek.v3.2', 'high')).toEqual({});
+  });
+
+  it('none on unsupported family is a silent no-op (nothing to disable)', () => {
+    expect(bedrockThinkingOptions('moonshotai.kimi-k2.5', 'none')).toEqual({});
+  });
+});
+
+describe('bedrockServiceTierOptions', () => {
+  it('should emit serviceTier under the bedrock namespace', () => {
+    expect(bedrockServiceTierOptions('flex')).toEqual({ bedrock: { serviceTier: 'flex' } });
+  });
+});
+
+describe('autoOpts bedrock branch', () => {
+  it('M7: noThinking maps to reasoningConfig disabled', () => {
+    expect(autoOpts.noThinking('bedrock:claude-haiku-4.5')).toEqual({
+      bedrock: { reasoningConfig: { type: 'disabled' } },
+    });
+  });
+
+  it('M8: thinking maps to budgetTokens for claude keys', () => {
+    expect(autoOpts.thinking('bedrock:claude-sonnet-4.5', 'low')).toEqual({
+      bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: 1024 } },
+    });
+  });
+
+  it('M9: thinking maps to maxReasoningEffort for nova 2 keys', () => {
+    expect(autoOpts.thinking('bedrock:nova-2-lite', 'medium')).toEqual({
+      bedrock: { reasoningConfig: { type: 'enabled', maxReasoningEffort: 'medium' } },
+    });
+  });
+
+  it('M10: thinking on unsupported family returns empty options', () => {
+    expect(autoOpts.thinking('bedrock:kimi-k2.5', 'low')).toEqual({});
+  });
+
+  it('bare provider name cannot infer family and returns empty options with warning', () => {
+    expect(autoOpts.noThinking('bedrock')).toEqual({});
+    expect(autoOpts.thinking('bedrock', 'low')).toEqual({});
+  });
+});

--- a/features/llm/clients/bedrock.client.spec.ts
+++ b/features/llm/clients/bedrock.client.spec.ts
@@ -17,6 +17,16 @@ describe('inferBedrockReasoningFamily', () => {
     expect(inferBedrockReasoningFamily('anthropic.claude-opus-4-6-v1')).toBe('anthropic');
   });
 
+  it('should detect adaptive-only anthropic models (Opus 4.7+, Sonnet 5, Fable 5)', () => {
+    expect(inferBedrockReasoningFamily('us.anthropic.claude-opus-4-7')).toBe('anthropic-adaptive');
+    expect(inferBedrockReasoningFamily('us.anthropic.claude-opus-4-8')).toBe('anthropic-adaptive');
+    expect(inferBedrockReasoningFamily('us.anthropic.claude-sonnet-5')).toBe('anthropic-adaptive');
+    expect(inferBedrockReasoningFamily('us.anthropic.claude-fable-5')).toBe('anthropic-adaptive');
+    // 4.6 及更早仍然支持 enabled + budgetTokens（live 验证通过）
+    expect(inferBedrockReasoningFamily('us.anthropic.claude-opus-4-6-v1')).toBe('anthropic');
+    expect(inferBedrockReasoningFamily('us.anthropic.claude-sonnet-4-6')).toBe('anthropic');
+  });
+
   it('should detect amazon nova 2 family', () => {
     expect(inferBedrockReasoningFamily('us.amazon.nova-2-lite-v1:0')).toBe('amazon-nova');
     expect(inferBedrockReasoningFamily('amazon.nova-2-lite-v1:0')).toBe('amazon-nova');
@@ -60,6 +70,15 @@ describe('bedrockThinkingOptions', () => {
     });
   });
 
+  it('effort maps to adaptive + maxReasoningEffort for adaptive-only Claude models', () => {
+    expect(bedrockThinkingOptions('us.anthropic.claude-opus-4-7', 'low')).toEqual({
+      bedrock: { reasoningConfig: { type: 'adaptive', maxReasoningEffort: 'low' } },
+    });
+    expect(bedrockThinkingOptions('us.anthropic.claude-opus-4-8', 'high')).toEqual({
+      bedrock: { reasoningConfig: { type: 'adaptive', maxReasoningEffort: 'high' } },
+    });
+  });
+
   it('M10: effort on unsupported family is dropped with warning', () => {
     expect(bedrockThinkingOptions('moonshotai.kimi-k2.5', 'low')).toEqual({});
     expect(bedrockThinkingOptions('deepseek.v3.2', 'high')).toEqual({});
@@ -92,6 +111,12 @@ describe('autoOpts bedrock branch', () => {
   it('M9: thinking maps to maxReasoningEffort for nova 2 keys', () => {
     expect(autoOpts.thinking('bedrock:nova-2-lite', 'medium')).toEqual({
       bedrock: { reasoningConfig: { type: 'enabled', maxReasoningEffort: 'medium' } },
+    });
+  });
+
+  it('thinking maps to adaptive for the registered opus-4.7 key', () => {
+    expect(autoOpts.thinking('bedrock:claude-opus-4.7', 'low')).toEqual({
+      bedrock: { reasoningConfig: { type: 'adaptive', maxReasoningEffort: 'low' } },
     });
   });
 

--- a/features/llm/clients/bedrock.client.ts
+++ b/features/llm/clients/bedrock.client.ts
@@ -2,7 +2,9 @@
  * AWS Bedrock Provider Options Helpers
  *
  * Bedrock Converse API 的 reasoningConfig 支持按模型家族区分：
- * - Anthropic Claude（含 us./global. inference profile 前缀）：budgetTokens（min 1024）
+ * - Anthropic Claude ≤4.6（含 us./global. inference profile 前缀）：budgetTokens（min 1024）
+ * - Anthropic Claude Opus 4.7+ / Sonnet 5 / Fable 5：仅支持 adaptive thinking，
+ *   `type: "enabled" + budget_tokens` 会 400，必须用 `type: "adaptive"` + `output_config.effort`
  * - Amazon Nova 2 系列：maxReasoningEffort（low/medium/high）
  * - 其他家族（kimi/deepseek/minimax/nova 1 代等）：不支持 reasoningConfig，
  *   发送会被 Converse 校验拒绝，因此一律不下发（显式请求 effort 时 warning）
@@ -18,7 +20,18 @@ import type { JSONObject } from '@ai-sdk/provider';
 const bedrockOptionsLogger = getAppLogger('features', 'LLM', 'bedrock');
 
 /** 支持 reasoningConfig 的模型家族 */
-export type BedrockReasoningFamily = 'anthropic' | 'amazon-nova' | 'other';
+export type BedrockReasoningFamily = 'anthropic' | 'anthropic-adaptive' | 'amazon-nova' | 'other';
+
+/**
+ * 仅支持 adaptive thinking 的 Claude 模型（Opus 4.7 起）。
+ *
+ * 这些模型对旧式 `thinking.type: "enabled" + budget_tokens` 返回 400：
+ * "Use thinking.type.adaptive and output_config.effort to control thinking behavior."
+ * 与 @ai-sdk/amazon-bedrock 内部的 special-case 列表（opus-4-7/4-8、sonnet-5、fable-5）对齐。
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html （Opus 4.7 model card）
+ */
+const ADAPTIVE_ONLY_PATTERN = /claude-(opus-4-[78]|sonnet-5|fable-5)/;
 
 /**
  * 从 Bedrock modelId 推断 reasoning 配置形式
@@ -27,7 +40,9 @@ export type BedrockReasoningFamily = 'anthropic' | 'amazon-nova' | 'other';
  * 只有 Nova 2 系列支持 maxReasoningEffort。
  */
 export function inferBedrockReasoningFamily(modelId: string): BedrockReasoningFamily {
-  if (modelId.includes('anthropic.')) return 'anthropic';
+  if (modelId.includes('anthropic.')) {
+    return ADAPTIVE_ONLY_PATTERN.test(modelId) ? 'anthropic-adaptive' : 'anthropic';
+  }
   if (/amazon\.nova-2/.test(modelId)) return 'amazon-nova';
   return 'other';
 }
@@ -55,6 +70,9 @@ export function bedrockThinkingOptions(
   switch (family) {
     case 'anthropic':
       return { bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: BEDROCK_BUDGET_MAP[effort] } } };
+    case 'anthropic-adaptive':
+      // Opus 4.7+：thinking.type=adaptive + output_config.effort（budget_tokens 会 400）
+      return { bedrock: { reasoningConfig: { type: 'adaptive', maxReasoningEffort: effort } } };
     case 'amazon-nova':
       return { bedrock: { reasoningConfig: { type: 'enabled', maxReasoningEffort: effort } } };
     default:

--- a/features/llm/clients/bedrock.client.ts
+++ b/features/llm/clients/bedrock.client.ts
@@ -1,0 +1,69 @@
+/**
+ * AWS Bedrock Provider Options Helpers
+ *
+ * Bedrock Converse API 的 reasoningConfig 支持按模型家族区分：
+ * - Anthropic Claude（含 us./global. inference profile 前缀）：budgetTokens（min 1024）
+ * - Amazon Nova 2 系列：maxReasoningEffort（low/medium/high）
+ * - 其他家族（kimi/deepseek/minimax/nova 1 代等）：不支持 reasoningConfig，
+ *   发送会被 Converse 校验拒绝，因此一律不下发（显式请求 effort 时 warning）
+ *
+ * @see https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock#reasoning
+ */
+
+import { getAppLogger } from '@app/utils/app-logger';
+
+import type { BedrockServiceTier } from '../types/model.types';
+import type { JSONObject } from '@ai-sdk/provider';
+
+const bedrockOptionsLogger = getAppLogger('features', 'LLM', 'bedrock');
+
+/** 支持 reasoningConfig 的模型家族 */
+export type BedrockReasoningFamily = 'anthropic' | 'amazon-nova' | 'other';
+
+/**
+ * 从 Bedrock modelId 推断 reasoning 配置形式
+ *
+ * 注意 Nova 1 代（nova-pro/nova-lite/nova-micro）不支持 reasoningConfig，
+ * 只有 Nova 2 系列支持 maxReasoningEffort。
+ */
+export function inferBedrockReasoningFamily(modelId: string): BedrockReasoningFamily {
+  if (modelId.includes('anthropic.')) return 'anthropic';
+  if (/amazon\.nova-2/.test(modelId)) return 'amazon-nova';
+  return 'other';
+}
+
+/** Thinking effort → Anthropic budgetTokens（与 google budgetMap 对齐；Bedrock 下限 1024） */
+const BEDROCK_BUDGET_MAP = { low: 1024, medium: 4096, high: 8192 } as const;
+
+/**
+ * 生成 Bedrock thinking/reasoning providerOptions
+ *
+ * - effort='none'：支持 reasoning 的家族下发 `{ type: 'disabled' }`；其他家族无推理可关，返回 {}
+ * - effort≠'none'：anthropic → budgetTokens；amazon-nova → maxReasoningEffort；其他家族 warn + 返回 {}
+ */
+export function bedrockThinkingOptions(
+  modelId: string,
+  effort: 'none' | 'low' | 'medium' | 'high',
+): { bedrock?: JSONObject } {
+  const family = inferBedrockReasoningFamily(modelId);
+
+  if (effort === 'none') {
+    if (family === 'other') return {};
+    return { bedrock: { reasoningConfig: { type: 'disabled' } } };
+  }
+
+  switch (family) {
+    case 'anthropic':
+      return { bedrock: { reasoningConfig: { type: 'enabled', budgetTokens: BEDROCK_BUDGET_MAP[effort] } } };
+    case 'amazon-nova':
+      return { bedrock: { reasoningConfig: { type: 'enabled', maxReasoningEffort: effort } } };
+    default:
+      bedrockOptionsLogger.warning`[bedrockThinkingOptions] reasoning effort=${effort} requested for unsupported model family (modelId=${modelId}), ignoring`;
+      return {};
+  }
+}
+
+/** 生成 Bedrock serviceTier providerOptions（`bedrock.serviceTier` spec 参数） */
+export function bedrockServiceTierOptions(serviceTier: BedrockServiceTier): { bedrock: JSONObject } {
+  return { bedrock: { serviceTier } };
+}

--- a/features/llm/clients/bedrock.integration.spec.ts
+++ b/features/llm/clients/bedrock.integration.spec.ts
@@ -29,9 +29,10 @@ interface CapturedRequest {
 let capturedRequests: CapturedRequest[] = [];
 const originalFetch = ApiFetcher.fetch;
 
-const AWS_ENV_KEYS = ['AWS_BEARER_TOKEN_BEDROCK', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'] as const;
+const AWS_ENV_KEYS = ['AWS_BEARER_TOKEN_BEDROCK', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_REGION'] as const;
 let savedAwsEnv: Record<string, string | undefined> = {};
 let savedBedrockApiKey: string | undefined;
+let savedBedrockRegion: string | undefined;
 let savedOpenRouterApiKey: string | undefined;
 
 beforeEach(() => {
@@ -44,6 +45,8 @@ beforeEach(() => {
   }
   savedBedrockApiKey = sysEnvMut.AI_BEDROCK_API_KEY;
   sysEnvMut.AI_BEDROCK_API_KEY = 'test-bedrock-key';
+  savedBedrockRegion = sysEnvMut.AI_BEDROCK_REGION;
+  delete sysEnvMut.AI_BEDROCK_REGION;
   // prepareStep 测试的 base model 走 openrouter
   savedOpenRouterApiKey = sysEnvMut.AI_OPENROUTER_API_KEY;
   sysEnvMut.AI_OPENROUTER_API_KEY = 'test-openrouter-key';
@@ -73,6 +76,8 @@ afterEach(() => {
   }
   if (savedBedrockApiKey === undefined) delete sysEnvMut.AI_BEDROCK_API_KEY;
   else sysEnvMut.AI_BEDROCK_API_KEY = savedBedrockApiKey;
+  if (savedBedrockRegion === undefined) delete sysEnvMut.AI_BEDROCK_REGION;
+  else sysEnvMut.AI_BEDROCK_REGION = savedBedrockRegion;
   if (savedOpenRouterApiKey === undefined) delete sysEnvMut.AI_OPENROUTER_API_KEY;
   else sysEnvMut.AI_OPENROUTER_API_KEY = savedOpenRouterApiKey;
   resetLLMClients();
@@ -130,6 +135,53 @@ describe('bedrock client', () => {
     const authorization = capturedRequests[0]!.headers.get('authorization') ?? '';
     expect(authorization).toContain('AWS4-HMAC-SHA256');
     expect(authorization).toContain('test-akid');
+  });
+
+  it('region: AWS_REGION is honored when AI_BEDROCK_REGION is unset', async () => {
+    process.env.AWS_REGION = 'us-west-2';
+
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-aws-region',
+        model: 'bedrock:claude-haiku-4.5',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+    expect(capturedRequests[0]!.url).toContain('bedrock-runtime.us-west-2');
+  });
+
+  it('region: AI_BEDROCK_REGION takes precedence over AWS_REGION', async () => {
+    sysEnvMut.AI_BEDROCK_REGION = 'us-east-2';
+    process.env.AWS_REGION = 'us-west-2';
+
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-region-precedence',
+        model: 'bedrock:claude-haiku-4.5',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+    expect(capturedRequests[0]!.url).toContain('bedrock-runtime.us-east-2');
+  });
+
+  it('region: defaults to us-east-1 when nothing is configured', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-region-default',
+        model: 'bedrock:claude-haiku-4.5',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+    expect(capturedRequests[0]!.url).toContain('bedrock-runtime.us-east-1');
   });
 });
 

--- a/features/llm/clients/bedrock.integration.spec.ts
+++ b/features/llm/clients/bedrock.integration.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * AWS Bedrock provider integration tests.
+ *
+ * 复用 llm.ai-options.integration.spec.ts 的 captured-fetch 模式：
+ * mock 共享 ApiFetcher，验证请求边界（URL / headers / body），不触达外部服务。
+ *
+ * 覆盖 spec 的 M5/M6/M11/M12/N1/S2。
+ */
+
+import 'reflect-metadata';
+
+import { SysEnv } from '@app/env';
+import { ApiFetcher } from '@app/utils/fetch';
+
+import { model } from './auto.client';
+import { LLM } from './llm.class';
+import { resetLLMClients } from './llm.clients';
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+const sysEnvMut = SysEnv as unknown as Record<string, string | undefined>;
+
+interface CapturedRequest {
+  url: string;
+  headers: Headers;
+  body: string | undefined;
+}
+
+let capturedRequests: CapturedRequest[] = [];
+const originalFetch = ApiFetcher.fetch;
+
+const AWS_ENV_KEYS = ['AWS_BEARER_TOKEN_BEDROCK', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'] as const;
+let savedAwsEnv: Record<string, string | undefined> = {};
+let savedBedrockApiKey: string | undefined;
+let savedOpenRouterApiKey: string | undefined;
+
+beforeEach(() => {
+  capturedRequests = [];
+  // 隔离 AWS 凭证环境变量，避免本地开发环境污染测试
+  savedAwsEnv = {};
+  for (const key of AWS_ENV_KEYS) {
+    savedAwsEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  savedBedrockApiKey = sysEnvMut.AI_BEDROCK_API_KEY;
+  sysEnvMut.AI_BEDROCK_API_KEY = 'test-bedrock-key';
+  // prepareStep 测试的 base model 走 openrouter
+  savedOpenRouterApiKey = sysEnvMut.AI_OPENROUTER_API_KEY;
+  sysEnvMut.AI_OPENROUTER_API_KEY = 'test-openrouter-key';
+
+  (ApiFetcher as unknown as { fetch: typeof fetch }).fetch = (async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    capturedRequests.push({
+      url: typeof url === 'string' ? url : url instanceof URL ? url.href : url.url,
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    });
+    return new Response(JSON.stringify({ error: { code: 400, message: 'mock-fetch' } }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  resetLLMClients();
+});
+
+afterEach(() => {
+  (ApiFetcher as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+  for (const key of AWS_ENV_KEYS) {
+    if (savedAwsEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedAwsEnv[key];
+  }
+  if (savedBedrockApiKey === undefined) delete sysEnvMut.AI_BEDROCK_API_KEY;
+  else sysEnvMut.AI_BEDROCK_API_KEY = savedBedrockApiKey;
+  if (savedOpenRouterApiKey === undefined) delete sysEnvMut.AI_OPENROUTER_API_KEY;
+  else sysEnvMut.AI_OPENROUTER_API_KEY = savedOpenRouterApiKey;
+  resetLLMClients();
+});
+
+async function callIgnoringError(fn: () => Promise<unknown> | unknown): Promise<void> {
+  try {
+    const res = fn();
+    if (res && typeof (res as Promise<unknown>).then === 'function') {
+      await res;
+    }
+  } catch {
+    // mock fetch 返回 400；测试只断言发出的请求。
+  }
+}
+
+function firstJsonBody(): Record<string, unknown> {
+  expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+  const body = capturedRequests[0]?.body;
+  expect(body).toBeDefined();
+  return JSON.parse(body!) as Record<string, unknown>;
+}
+
+const SIMPLE_MESSAGE = [{ role: 'user' as const, content: 'test' }];
+
+describe('bedrock client', () => {
+  it('M5: model() routes bedrock keys to the bedrock provider', () => {
+    const languageModel = model('bedrock:claude-haiku-4.5') as { provider: string; modelId: string };
+    expect(languageModel.provider).toBe('amazon-bedrock');
+    expect(languageModel.modelId).toBe('us.anthropic.claude-haiku-4-5-20251001-v1:0');
+  });
+
+  it('M6: model() fails fast with actionable error when no credentials exist', () => {
+    delete sysEnvMut.AI_BEDROCK_API_KEY;
+    expect(() => model('bedrock:claude-haiku-4.5')).toThrow(
+      /AI_BEDROCK_API_KEY.*AWS_BEARER_TOKEN_BEDROCK.*AWS_ACCESS_KEY_ID/s,
+    );
+  });
+
+  it('M6/S2: SigV4 env credentials alone are accepted and used for signing', async () => {
+    delete sysEnvMut.AI_BEDROCK_API_KEY;
+    process.env.AWS_ACCESS_KEY_ID = 'test-akid';
+    process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
+
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-sigv4',
+        model: 'bedrock:claude-haiku-4.5',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+    const authorization = capturedRequests[0]!.headers.get('authorization') ?? '';
+    expect(authorization).toContain('AWS4-HMAC-SHA256');
+    expect(authorization).toContain('test-akid');
+  });
+});
+
+describe('bedrock request payload', () => {
+  it('M11/S2: serviceTier + reasoning budget land in the Converse payload via ApiFetcher', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-service-tier-reason',
+        model: 'bedrock:claude-sonnet-4.5?bedrock.serviceTier=flex&reason=low',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+    const first = capturedRequests[0]!;
+    // 请求经 ApiFetcher.fetch 发出（被本测试捕获即证明 S2）
+    expect(first.url).toContain('bedrock-runtime.');
+    expect(first.url).toContain('us.anthropic.claude-sonnet-4-5');
+    expect(first.headers.get('authorization')).toBe('Bearer test-bedrock-key');
+
+    const body = firstJsonBody();
+    expect(body.serviceTier).toEqual({ type: 'flex' });
+    const additional = body.additionalModelRequestFields as Record<string, unknown>;
+    expect(additional.thinking).toEqual({ type: 'enabled', budget_tokens: 1024 });
+  });
+
+  it('M11: thinking=none emits reasoningConfig disabled for anthropic keys', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-no-thinking',
+        model: 'bedrock:claude-haiku-4.5',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    const body = firstJsonBody();
+    // type=disabled 时 provider 不下发 thinking 字段，也不应有 serviceTier
+    expect(JSON.stringify(body)).not.toContain('reasoningConfig');
+    expect(JSON.stringify(body)).not.toContain('thinking');
+    expect(body.serviceTier).toBeUndefined();
+  });
+
+  it('M12: reasoningRequired model with reason=none never receives disable options', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-reasoning-required',
+        model: 'bedrock:kimi-k2-thinking?reason=none',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+    expect(capturedRequests[0]!.url).toContain('moonshot.kimi-k2-thinking');
+    const body = firstJsonBody();
+    expect(JSON.stringify(body)).not.toContain('reasoningConfig');
+    expect(JSON.stringify(body)).not.toContain('thinking');
+  });
+
+  it('N1: prepareStep.llm.model routes step request to bedrock with step thinking', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-prepare-step',
+        model: 'openrouter:grok-4.1-fast',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+        ai: {
+          prepareStep: () => ({
+            llm: { model: 'bedrock:claude-haiku-4.5?reason=low' },
+          }),
+        },
+      }),
+    );
+
+    expect(capturedRequests.length).toBeGreaterThanOrEqual(1);
+    const first = capturedRequests[0]!;
+    expect(first.url).toContain('bedrock-runtime.');
+    expect(first.url).toContain('us.anthropic.claude-haiku-4-5');
+    const body = firstJsonBody();
+    const additional = body.additionalModelRequestFields as Record<string, unknown>;
+    expect(additional.thinking).toEqual({ type: 'enabled', budget_tokens: 1024 });
+  });
+});

--- a/features/llm/clients/bedrock.integration.spec.ts
+++ b/features/llm/clients/bedrock.integration.spec.ts
@@ -29,7 +29,16 @@ interface CapturedRequest {
 let capturedRequests: CapturedRequest[] = [];
 const originalFetch = ApiFetcher.fetch;
 
-const AWS_ENV_KEYS = ['AWS_BEARER_TOKEN_BEDROCK', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_REGION'] as const;
+const AWS_ENV_KEYS = [
+  'AWS_BEARER_TOKEN_BEDROCK',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_REGION',
+  'AWS_PROFILE',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+] as const;
 let savedAwsEnv: Record<string, string | undefined> = {};
 let savedBedrockApiKey: string | undefined;
 let savedBedrockRegion: string | undefined;
@@ -115,6 +124,18 @@ describe('bedrock client', () => {
     expect(() => model('bedrock:claude-haiku-4.5')).toThrow(
       /AI_BEDROCK_API_KEY.*AWS_BEARER_TOKEN_BEDROCK.*AWS_ACCESS_KEY_ID/s,
     );
+  });
+
+  it('M6: error hints at profile export when only AWS_PROFILE is set', () => {
+    delete sysEnvMut.AI_BEDROCK_API_KEY;
+    process.env.AWS_PROFILE = 'mission-ai-v2';
+    expect(() => model('bedrock:claude-haiku-4.5')).toThrow(/AWS_PROFILE.*export static credentials/s);
+  });
+
+  it('M6: error names deferred credential chain when IRSA env is detected', () => {
+    delete sysEnvMut.AI_BEDROCK_API_KEY;
+    process.env.AWS_WEB_IDENTITY_TOKEN_FILE = '/var/run/secrets/eks.amazonaws.com/serviceaccount/token';
+    expect(() => model('bedrock:claude-haiku-4.5')).toThrow(/IAM role credentials detected.*not wired yet/s);
   });
 
   it('M6/S2: SigV4 env credentials alone are accepted and used for signing', async () => {

--- a/features/llm/clients/bedrock.integration.spec.ts
+++ b/features/llm/clients/bedrock.integration.spec.ts
@@ -12,11 +12,14 @@ import 'reflect-metadata';
 import { SysEnv } from '@app/env';
 import { ApiFetcher } from '@app/utils/fetch';
 
+import { registerModel } from '../types/model.types';
 import { model } from './auto.client';
 import { LLM } from './llm.class';
 import { resetLLMClients } from './llm.clients';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import type { LLMModelSpec } from '../types/model.types';
 
 const sysEnvMut = SysEnv as unknown as Record<string, string | undefined>;
 
@@ -247,11 +250,15 @@ describe('bedrock request payload', () => {
     expect(body.serviceTier).toBeUndefined();
   });
 
-  it('adaptive-only model (opus-4.7) emits thinking.type=adaptive + output_config.effort', async () => {
+  it('adaptive-only model emits thinking.type=adaptive + output_config.effort', async () => {
+    // 注册的 12 个 key 均非 adaptive-only（opus-4.7 因账户未开通已移除），
+    // 用 registerModel 扩展点注册测试专用 key 覆盖 adaptive 家族 wire shape。
+    registerModel('bedrock:test-adaptive-only', { provider: 'bedrock', modelId: 'us.anthropic.claude-opus-4-8' });
+
     await callIgnoringError(() =>
       LLM.generateText({
         id: 'bedrock-adaptive-thinking',
-        model: 'bedrock:claude-opus-4.7?reason=low',
+        model: 'bedrock:test-adaptive-only?reason=low' as LLMModelSpec,
         messages: SIMPLE_MESSAGE,
         maxRetries: 0,
       }),

--- a/features/llm/clients/bedrock.integration.spec.ts
+++ b/features/llm/clients/bedrock.integration.spec.ts
@@ -247,6 +247,24 @@ describe('bedrock request payload', () => {
     expect(body.serviceTier).toBeUndefined();
   });
 
+  it('adaptive-only model (opus-4.7) emits thinking.type=adaptive + output_config.effort', async () => {
+    await callIgnoringError(() =>
+      LLM.generateText({
+        id: 'bedrock-adaptive-thinking',
+        model: 'bedrock:claude-opus-4.7?reason=low',
+        messages: SIMPLE_MESSAGE,
+        maxRetries: 0,
+      }),
+    );
+
+    const body = firstJsonBody();
+    const additional = body.additionalModelRequestFields as Record<string, unknown>;
+    // Opus 4.7+ 对 enabled+budget_tokens 返回 400，必须是 adaptive + output_config.effort
+    expect(additional.thinking).toEqual({ type: 'adaptive' });
+    expect(additional.output_config).toEqual({ effort: 'low' });
+    expect(JSON.stringify(additional)).not.toContain('budget_tokens');
+  });
+
   it('M12: reasoningRequired model with reason=none never receives disable options', async () => {
     await callIgnoringError(() =>
       LLM.generateText({

--- a/features/llm/clients/bedrock.live.spec.ts
+++ b/features/llm/clients/bedrock.live.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * AWS Bedrock live smoke test（spec S1）
+ *
+ * ⚠️ 不在 CI 运行：仅当显式设置 LLM_LIVE_TEST=1 且本地存在 Bedrock 凭证时执行。
+ * CI（bun test --coverage）不会设置 LLM_LIVE_TEST，整个 describe 被 skip。
+ *
+ * 运行方式（SigV4，使用 mission-ai-v2 profile）：
+ * ```bash
+ * eval "$(aws configure export-credentials --profile mission-ai-v2 --format env)"
+ * AI_BEDROCK_REGION=us-east-2 LLM_LIVE_TEST=1 bun test features/llm/clients/bedrock.live.spec.ts
+ * ```
+ *
+ * 或使用 Bedrock API key：
+ * ```bash
+ * AI_BEDROCK_API_KEY=xxx AI_BEDROCK_REGION=us-east-2 LLM_LIVE_TEST=1 bun test features/llm/clients/bedrock.live.spec.ts
+ * ```
+ */
+
+import 'reflect-metadata';
+
+import { LLM } from './llm.class';
+
+import { describe, expect, it } from 'bun:test';
+
+const LIVE = process.env.LLM_LIVE_TEST === '1';
+const describeLive = LIVE ? describe : describe.skip;
+
+describeLive('bedrock live smoke (LLM_LIVE_TEST=1)', () => {
+  it('generateText on bedrock:claude-haiku-4.5 returns text and usage', async () => {
+    const result = await LLM.generateText({
+      id: 'bedrock-live-smoke',
+      model: 'bedrock:claude-haiku-4.5',
+      messages: [{ role: 'user', content: 'Reply with exactly: hello bedrock' }],
+      maxRetries: 0,
+      timeout: 30_000,
+    });
+
+    console.log('[live-smoke] text:', result.text);
+    console.log('[live-smoke] usage:', JSON.stringify(result.usage));
+
+    expect(result.text.length).toBeGreaterThan(0);
+    const usage = result.usage as Record<string, unknown>;
+    const inputTokens = (usage.inputTokens ?? usage.promptTokens ?? 0) as number;
+    const outputTokens = (usage.outputTokens ?? usage.completionTokens ?? 0) as number;
+    expect(inputTokens).toBeGreaterThan(0);
+    expect(outputTokens).toBeGreaterThan(0);
+  }, 45_000);
+});

--- a/features/llm/clients/bedrock.live.spec.ts
+++ b/features/llm/clients/bedrock.live.spec.ts
@@ -4,23 +4,26 @@
  * ⚠️ 不在 CI 运行：仅当显式设置 LLM_LIVE_TEST=1 且本地存在 Bedrock 凭证时执行。
  * CI（bun test --coverage）不会设置 LLM_LIVE_TEST，整个 describe 被 skip。
  *
- * 运行方式（SigV4，使用 mission-ai-v2 profile）：
+ * 运行方式（凭证已在 .env 中配置时）：
  * ```bash
- * eval "$(aws configure export-credentials --profile mission-ai-v2 --format env)"
- * AI_BEDROCK_REGION=us-east-2 LLM_LIVE_TEST=1 bun test features/llm/clients/bedrock.live.spec.ts
+ * LLM_LIVE_TEST=1 bun test features/llm/clients/bedrock.live.spec.ts
  * ```
  *
- * 或使用 Bedrock API key：
+ * 或使用其他 profile 的 SigV4 凭证：
  * ```bash
- * AI_BEDROCK_API_KEY=xxx AI_BEDROCK_REGION=us-east-2 LLM_LIVE_TEST=1 bun test features/llm/clients/bedrock.live.spec.ts
+ * eval "$(aws configure export-credentials --profile <name> --format env)"
+ * AI_BEDROCK_REGION=us-east-2 LLM_LIVE_TEST=1 bun test features/llm/clients/bedrock.live.spec.ts
  * ```
  */
 
 import 'reflect-metadata';
 
+import { getRegisteredModels } from '../types/model.types';
 import { LLM } from './llm.class';
 
 import { describe, expect, it } from 'bun:test';
+
+import type { LLMModelSpec } from '../types/model.types';
 
 const LIVE = process.env.LLM_LIVE_TEST === '1';
 const describeLive = LIVE ? describe : describe.skip;
@@ -45,4 +48,31 @@ describeLive('bedrock live smoke (LLM_LIVE_TEST=1)', () => {
     expect(inputTokens).toBeGreaterThan(0);
     expect(outputTokens).toBeGreaterThan(0);
   }, 45_000);
+
+  it('every registered bedrock:* key is actually invocable on this account', async () => {
+    // get-foundation-model-availability 可能误报（opus-4.7 曾 AUTHORIZED 但不可调用），
+    // 只有真实调用能证明 key 可用；发现不可用的 key 应从 registry 移除。
+    const keys = getRegisteredModels().filter((k) => k.startsWith('bedrock:')) as LLMModelSpec[];
+    expect(keys.length).toBeGreaterThan(0);
+
+    const failures: string[] = [];
+    for (const key of keys) {
+      try {
+        const r = await LLM.generateText({
+          id: 'live-invocability',
+          model: key,
+          messages: [{ role: 'user', content: 'Reply with exactly: ok' }],
+          maxRetries: 0,
+          timeout: 60_000,
+        });
+        console.log(`[live-smoke] ${key}: OK ${JSON.stringify(r.text.slice(0, 20))}`);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.log(`[live-smoke] ${key}: FAIL ${msg.slice(0, 160)}`);
+        failures.push(key);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  }, 600_000);
 });

--- a/features/llm/clients/index.ts
+++ b/features/llm/clients/index.ts
@@ -19,10 +19,13 @@
 
 // 自动路由（需要更多控制时）
 export { autoOpts, model, parseProvider } from './auto.client';
+export { bedrockServiceTierOptions, bedrockThinkingOptions, inferBedrockReasoningFamily } from './bedrock.client';
 export { createGoogleClient, googleOptions } from './google.client';
 export { createVertex, vertexOptions } from './vertex.client';
 // 预配置单例
 export {
+  bedrock,
+  getBedrockProvider,
   getGoogleProvider,
   getLLMClientStatus,
   google,

--- a/features/llm/clients/llm.class.ts
+++ b/features/llm/clients/llm.class.ts
@@ -67,6 +67,7 @@ import { z } from 'zod';
 import type { EmbeddingModel, EmbeddingModelKey, EmbeddingProvider, EmbeddingTaskType } from '../types/embedding.types';
 import type {
   BedrockModelOptions,
+  BedrockServiceTier,
   LLMModelKey,
   LLMModelSpec,
   OpenRouterModelOptions,
@@ -999,19 +1000,21 @@ export class LLM {
     fb?: FallbackAttempt,
     tier?: VertexTier,
     vertexRequestType?: VertexRequestType,
+    bedrockServiceTier?: BedrockServiceTier,
   ): void {
     const duration = Date.now() - startTime;
     const inputTokens = usage.inputTokens ?? usage.promptTokens ?? 0;
     const outputTokens = usage.outputTokens ?? usage.completionTokens ?? 0;
     const totalTokens = inputTokens + outputTokens;
-    const cost = getCostFromUsage(usage, modelKey);
+    const cost = getCostFromUsage(usage, modelKey, { bedrockServiceTier });
     const costStr = cost !== null ? `, cost=$${cost.toFixed(6)}` : '';
     const fbPart = fb && fb.total > 1 ? `, attempt=${fb.attempt}/${fb.total}` : '';
     const trafficType = extractTrafficType(usage);
     const trafficPart = trafficType ? `, trafficType=${trafficType}` : '';
     const tierPart = formatTierLogPart(tier, vertexRequestType);
+    const serviceTierPart = bedrockServiceTier ? `, bedrockServiceTier=${bedrockServiceTier}` : '';
     LLM.logger
-      .info`[LLM:end] id=${id}, method=${method}, model=${modelKey}${tierPart}, duration=${duration}ms, tokens=${totalTokens || '-'} (in=${inputTokens}, out=${outputTokens})${costStr}${fbPart}${trafficPart}`;
+      .info`[LLM:end] id=${id}, method=${method}, model=${modelKey}${tierPart}${serviceTierPart}, duration=${duration}ms, tokens=${totalTokens || '-'} (in=${inputTokens}, out=${outputTokens})${costStr}${fbPart}${trafficPart}`;
   }
 
   private static logTTFT(id: string, startTime: number): void {
@@ -1136,6 +1139,7 @@ export class LLM {
           fb,
           spec.vertex?.tier,
           spec.vertex?.requestType,
+          spec.bedrock?.serviceTier,
         );
 
         return {
@@ -1373,6 +1377,7 @@ export class LLM {
           fb,
           spec.vertex?.tier,
           spec.vertex?.requestType,
+          spec.bedrock?.serviceTier,
         );
 
         return {
@@ -1496,6 +1501,7 @@ export class LLM {
             undefined,
             spec.vertex?.tier,
             spec.vertex?.requestType,
+            spec.bedrock?.serviceTier,
           );
         },
         logAbort: () => {
@@ -1644,6 +1650,7 @@ export class LLM {
             undefined,
             spec.vertex?.tier,
             spec.vertex?.requestType,
+            spec.bedrock?.serviceTier,
           );
         },
         logAbort: () => {
@@ -1821,6 +1828,7 @@ export class LLM {
           fb,
           spec.vertex?.tier,
           spec.vertex?.requestType,
+          spec.bedrock?.serviceTier,
         );
 
         // 从 toolCalls 中提取结果（只取第一个，忽略可能的重复 tool call）
@@ -2036,6 +2044,7 @@ export class LLM {
         undefined,
         spec.vertex?.tier,
         spec.vertex?.requestType,
+        spec.bedrock?.serviceTier,
       );
       yield { type: 'usage', usage };
     } catch (error) {

--- a/features/llm/clients/llm.class.ts
+++ b/features/llm/clients/llm.class.ts
@@ -39,6 +39,7 @@ import { EMBEDDING_MODELS } from '../types/embedding.types';
 import { DEFAULT_SUPPORTED_TIERS, getModel, parseModelSpec } from '../types/model.types';
 import { getCostFromUsage } from '../utils/cost-calculator';
 import { model as createModel, parseProvider } from './auto.client';
+import { bedrockServiceTierOptions } from './bedrock.client';
 import { getOpenAI, getOpenRouter } from './llm.clients';
 import { resolveOpenRouterOptions } from './openrouter.client';
 import { disableThinkingOptions, reasoningEffortOptions } from './options.helpers';
@@ -65,6 +66,7 @@ import { z } from 'zod';
 
 import type { EmbeddingModel, EmbeddingModelKey, EmbeddingProvider, EmbeddingTaskType } from '../types/embedding.types';
 import type {
+  BedrockModelOptions,
   LLMModelKey,
   LLMModelSpec,
   OpenRouterModelOptions,
@@ -106,6 +108,7 @@ type ProviderOptionsSurface = {
   openrouter?: JSONObject;
   google?: JSONObject;
   vertex?: JSONObject;
+  bedrock?: JSONObject;
 };
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -323,6 +326,8 @@ interface ResolvedSpec {
   vertex: VertexModelOptions | undefined;
   /** OpenRouter provider-namespaced options. */
   openrouter: OpenRouterModelOptions | undefined;
+  /** Bedrock provider-namespaced options. */
+  bedrock: BedrockModelOptions | undefined;
 }
 
 const specLogger = getAppLogger('features', 'LLM', 'spec');
@@ -347,6 +352,7 @@ function resolveSpec(
   const fallbackModels = parsed.fallbackModels;
   const vertex = parsed.vertex;
   const openrouter = parsed.openrouter;
+  const bedrock = parsed.bedrock;
 
   // 有非默认参数时打印生效值，方便排查
   const hasSpecParams =
@@ -355,7 +361,8 @@ function resolveSpec(
     parsed.timeout !== undefined ||
     fallbackModels.length > 0 ||
     vertex !== undefined ||
-    openrouter !== undefined;
+    openrouter !== undefined ||
+    bedrock !== undefined;
   if (hasSpecParams) {
     const parts: string[] = [];
     if (thinking !== 'none') parts.push(`thinking=${thinking}`);
@@ -365,6 +372,7 @@ function resolveSpec(
     if (vertex?.tier !== undefined) parts.push(`vertex.tier=${vertex.tier}`);
     if (vertex?.requestType !== undefined) parts.push(`vertex.requestType=${vertex.requestType}`);
     if (openrouter?.routing !== undefined) parts.push(`openrouter.routing=${openrouter.routing}`);
+    if (bedrock?.serviceTier !== undefined) parts.push(`bedrock.serviceTier=${bedrock.serviceTier}`);
     specLogger.info`[resolveSpec] ${parsed.key} → ${parts.join(', ')}`;
   }
 
@@ -377,6 +385,7 @@ function resolveSpec(
     fallbackModels,
     vertex,
     openrouter,
+    bedrock,
   };
 }
 
@@ -398,14 +407,30 @@ function buildProviderOptions(
   thinking: ThinkingEffort,
   modelKey: LLMModelKey,
   openrouter?: OpenRouterModelOptions,
+  bedrock?: BedrockModelOptions,
 ): ProviderOptionsSurface {
   const modelConfig = getModel(modelKey);
   const thinkingOptions: ProviderOptionsSurface =
     thinking === 'none'
       ? modelConfig.reasoningRequired
         ? {}
-        : disableThinkingOptions(provider)
-      : reasoningEffortOptions(provider, thinking);
+        : disableThinkingOptions(provider, modelConfig.modelId)
+      : reasoningEffortOptions(provider, thinking, modelConfig.modelId);
+
+  if (provider === 'bedrock') {
+    if (!bedrock?.serviceTier) return thinkingOptions;
+    const serviceTierOptions = bedrockServiceTierOptions(bedrock.serviceTier);
+    return {
+      bedrock: {
+        ...thinkingOptions.bedrock,
+        ...serviceTierOptions.bedrock,
+      },
+    };
+  }
+
+  if (bedrock) {
+    aiLogger.warning`[buildProviderOptions] bedrock options requested for non-bedrock provider=${provider} (model=${modelKey}), ignoring`;
+  }
 
   if (provider !== 'openrouter') {
     if (openrouter) {
@@ -551,7 +576,13 @@ function wrapPrepareStep<TOOLS extends ToolSet, RUNTIME_CONTEXT extends Context>
       model: createLanguageModelForCall(stepSpec.key, targetModelIdSuffix, {
         extractJson: context.extractJson,
       }),
-      providerOptions: buildProviderOptions(provider, stepSpec.thinking, stepSpec.key, stepOpenRouter),
+      providerOptions: buildProviderOptions(
+        provider,
+        stepSpec.thinking,
+        stepSpec.key,
+        stepOpenRouter,
+        stepSpec.bedrock,
+      ),
     };
   };
 }
@@ -1074,7 +1105,7 @@ export class LLM {
 
       const languageModel = createModel(modelKey);
       const provider = parseProvider(modelKey);
-      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
+      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions, spec.bedrock);
       const tierHeaders = buildTierHeaders(modelKey, spec.vertex?.tier, spec.vertex?.requestType);
 
       const { signal, cleanup } = createManagedSignal(spec.timeout, abortSignal);
@@ -1302,7 +1333,7 @@ export class LLM {
       );
       const languageModel = createLanguageModelForCall(modelKey, modelIdSuffix);
       const provider = parseProvider(modelKey);
-      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
+      const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions, spec.bedrock);
       const tierHeaders = buildTierHeaders(modelKey, spec.vertex?.tier, spec.vertex?.requestType);
       const headers = mergeHeaders(aiOptions?.headers, tierHeaders);
 
@@ -1421,7 +1452,7 @@ export class LLM {
     const model = createLanguageModelForCall(modelKey, undefined, { extractJson: true });
 
     const provider = parseProvider(modelKey);
-    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
+    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions, spec.bedrock);
     const tierHeaders = buildTierHeaders(modelKey, spec.vertex?.tier, spec.vertex?.requestType);
     const headers = mergeHeaders(aiOptions?.headers, tierHeaders);
 
@@ -1571,7 +1602,7 @@ export class LLM {
 
     const languageModel = createLanguageModelForCall(modelKey, undefined);
     const provider = parseProvider(modelKey);
-    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
+    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions, spec.bedrock);
     const tierHeaders = buildTierHeaders(modelKey, spec.vertex?.tier, spec.vertex?.requestType);
     const headers = mergeHeaders(aiOptions?.headers, tierHeaders);
 
@@ -1729,7 +1760,13 @@ export class LLM {
 
       const languageModel = createModel(modelKey);
       const provider = parseProvider(modelKey);
-      const baseProviderOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
+      const baseProviderOptions = buildProviderOptions(
+        provider,
+        spec.thinking,
+        modelKey,
+        openrouterOptions,
+        spec.bedrock,
+      );
 
       // OpenRouter 支持 parallelToolCalls 参数控制并行 tool call
       const providerOptions =
@@ -1919,7 +1956,7 @@ export class LLM {
 
     const languageModel = createModel(modelKey);
     const provider = parseProvider(modelKey);
-    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions);
+    const providerOptions = buildProviderOptions(provider, spec.thinking, modelKey, openrouterOptions, spec.bedrock);
     const tierHeaders = buildTierHeaders(modelKey, spec.vertex?.tier, spec.vertex?.requestType);
 
     // 创建 Tool，将 Schema 作为 inputSchema

--- a/features/llm/clients/llm.clients.ts
+++ b/features/llm/clients/llm.clients.ts
@@ -335,7 +335,7 @@ export const vertexGlobal = (modelId: string): LanguageModel => getVertexGlobal(
  * 注意：provider 的 env fallback 只读 process env，不解析 AWS CLI profile；
  * 本地用 `aws configure export-credentials --profile <name> --format env` 导出。
  *
- * Region：SysEnv.AI_BEDROCK_REGION，默认 us-east-1；
+ * Region 优先级：SysEnv.AI_BEDROCK_REGION > AWS_REGION > us-east-1；
  * `us.*` inference profile（Claude 全系）需美国区域端点。
  */
 function getBedrock() {
@@ -348,7 +348,7 @@ function getBedrock() {
         'AWS Bedrock credentials are not configured. Set AI_BEDROCK_API_KEY, AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY',
       );
     }
-    const region = SysEnv.AI_BEDROCK_REGION ?? 'us-east-1';
+    const region = SysEnv.AI_BEDROCK_REGION ?? process.env.AWS_REGION ?? 'us-east-1';
     const auth = apiKey ? 'api-key' : hasBearerToken ? 'aws-bearer-token-env' : 'aws-sigv4-env';
     clientLogger.info`[bedrock:init] region=${region}, auth=${auth}, baseURL=default`;
     _bedrock = loadBedrockFactory()({

--- a/features/llm/clients/llm.clients.ts
+++ b/features/llm/clients/llm.clients.ts
@@ -58,12 +58,15 @@ import '@app/nest/exceptions/oops-factories';
 
 import { createVertexFetch } from './vertex.fetch';
 
-import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { createRequire } from 'node:module';
+
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createVertex } from '@ai-sdk/google-vertex';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 
+// type-only：编译期即被擦除，不会触发运行时模块解析（optional peer 惰性加载见下方 loadBedrockFactory）
+import type { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import type { LanguageModel } from 'ai';
 
 // ============================================================================
@@ -76,6 +79,32 @@ let _vertex: ReturnType<typeof createVertex> | null = null;
 let _vertexGlobal: ReturnType<typeof createVertex> | null = null;
 let _openai: ReturnType<typeof createOpenAI> | null = null;
 let _bedrock: ReturnType<typeof createAmazonBedrock> | null = null;
+
+// ============================================================================
+// Optional peer 惰性加载
+// ============================================================================
+
+/**
+ * `@ai-sdk/amazon-bedrock` 是 optional peer 且 ESM-only。
+ * 静态 import 会让未安装该包的既有使用者在加载本模块时就 ERR_MODULE_NOT_FOUND，
+ * 因此改为首次使用 bedrock 时才经 require(esm) 同步加载（Node ≥22.12 / bun 均支持）。
+ */
+let _createAmazonBedrock: typeof createAmazonBedrock | null = null;
+
+function loadBedrockFactory(): typeof createAmazonBedrock {
+  if (!_createAmazonBedrock) {
+    try {
+      const req = createRequire(import.meta.url);
+      const mod = req('@ai-sdk/amazon-bedrock') as { createAmazonBedrock: typeof createAmazonBedrock };
+      _createAmazonBedrock = mod.createAmazonBedrock;
+    } catch {
+      throw Oops.Panic.Config(
+        'bedrock:* models require the optional peer "@ai-sdk/amazon-bedrock". Install it first (e.g. bun add @ai-sdk/amazon-bedrock).',
+      );
+    }
+  }
+  return _createAmazonBedrock;
+}
 
 const clientLogger = getAppLogger('features', 'LLM', 'clients');
 
@@ -322,7 +351,7 @@ function getBedrock() {
     const region = SysEnv.AI_BEDROCK_REGION ?? 'us-east-1';
     const auth = apiKey ? 'api-key' : hasBearerToken ? 'aws-bearer-token-env' : 'aws-sigv4-env';
     clientLogger.info`[bedrock:init] region=${region}, auth=${auth}, baseURL=default`;
-    _bedrock = createAmazonBedrock({
+    _bedrock = loadBedrockFactory()({
       ...(apiKey ? { apiKey } : {}),
       region,
       fetch: ApiFetcher.fetch,

--- a/features/llm/clients/llm.clients.ts
+++ b/features/llm/clients/llm.clients.ts
@@ -15,6 +15,12 @@
  * | 复杂推理 | `google('gemini-2.5-pro')` | 推理能力强，thinking tokens 免费 |
  * | 大上下文 | `openrouter('x-ai/grok-4.1-fast')` | 2M context window |
  *
+ * ## Provider 选择：bedrock vs openrouter
+ *
+ * 同一模型家族（Claude/Kimi/DeepSeek/MiniMax）两边都有时的取舍：
+ * - `bedrock:*`：企业合规/数据驻留（流量不进第三方代理）、AWS 账单整合、serviceTier 分层
+ * - `openrouter:*`：模型更全、无需 AWS 凭证、定价透明
+ *
  * ## 价格参考（2026-01）
  *
  * | 模型 | Input | Output | 备注 |
@@ -52,6 +58,7 @@ import '@app/nest/exceptions/oops-factories';
 
 import { createVertexFetch } from './vertex.fetch';
 
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createVertex } from '@ai-sdk/google-vertex';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -68,6 +75,7 @@ let _google: ReturnType<typeof createGoogleGenerativeAI> | null = null;
 let _vertex: ReturnType<typeof createVertex> | null = null;
 let _vertexGlobal: ReturnType<typeof createVertex> | null = null;
 let _openai: ReturnType<typeof createOpenAI> | null = null;
+let _bedrock: ReturnType<typeof createAmazonBedrock> | null = null;
 
 const clientLogger = getAppLogger('features', 'LLM', 'clients');
 
@@ -284,6 +292,64 @@ function getVertexGlobal() {
 export const vertexGlobal = (modelId: string): LanguageModel => getVertexGlobal()(modelId);
 
 // ============================================================================
+// AWS Bedrock 客户端
+// ============================================================================
+
+/**
+ * 获取 AWS Bedrock 客户端单例
+ *
+ * 认证优先级（与 @ai-sdk/amazon-bedrock 一致）：
+ * 1. SysEnv.AI_BEDROCK_API_KEY（Bearer API key）
+ * 2. AWS_BEARER_TOKEN_BEDROCK 环境变量（provider 自身 fallback）
+ * 3. AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY（SigV4）
+ *
+ * 注意：provider 的 env fallback 只读 process env，不解析 AWS CLI profile；
+ * 本地用 `aws configure export-credentials --profile <name> --format env` 导出。
+ *
+ * Region：SysEnv.AI_BEDROCK_REGION，默认 us-east-1；
+ * `us.*` inference profile（Claude 全系）需美国区域端点。
+ */
+function getBedrock() {
+  if (!_bedrock) {
+    const apiKey = SysEnv.AI_BEDROCK_API_KEY;
+    const hasBearerToken = !!process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const hasSigV4 = !!process.env.AWS_ACCESS_KEY_ID && !!process.env.AWS_SECRET_ACCESS_KEY;
+    if (!apiKey && !hasBearerToken && !hasSigV4) {
+      throw Oops.Panic.Config(
+        'AWS Bedrock credentials are not configured. Set AI_BEDROCK_API_KEY, AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY',
+      );
+    }
+    const region = SysEnv.AI_BEDROCK_REGION ?? 'us-east-1';
+    const auth = apiKey ? 'api-key' : hasBearerToken ? 'aws-bearer-token-env' : 'aws-sigv4-env';
+    clientLogger.info`[bedrock:init] region=${region}, auth=${auth}, baseURL=default`;
+    _bedrock = createAmazonBedrock({
+      ...(apiKey ? { apiKey } : {}),
+      region,
+      fetch: ApiFetcher.fetch,
+    });
+  }
+  return _bedrock;
+}
+
+/**
+ * AWS Bedrock 模型选择器
+ *
+ * @example
+ * ```typescript
+ * bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+ * bedrock('moonshotai.kimi-k2.5')
+ * ```
+ */
+export const bedrock = (modelId: string): LanguageModel => getBedrock()(modelId);
+
+/**
+ * 获取 Bedrock Provider 实例（含 provider-defined tools）
+ */
+export function getBedrockProvider() {
+  return getBedrock();
+}
+
+// ============================================================================
 // 客户端状态检查
 // ============================================================================
 
@@ -308,6 +374,13 @@ export function getLLMClientStatus() {
       configured: !!SysEnv.GOOGLE_VERTEX_PROJECT,
       initialized: !!_vertexGlobal,
     },
+    bedrock: {
+      configured:
+        !!SysEnv.AI_BEDROCK_API_KEY ||
+        !!process.env.AWS_BEARER_TOKEN_BEDROCK ||
+        (!!process.env.AWS_ACCESS_KEY_ID && !!process.env.AWS_SECRET_ACCESS_KEY),
+      initialized: !!_bedrock,
+    },
 
     proxy: {
       enabled: SysEnv.APP_PROXY_ENABLED ?? false,
@@ -325,6 +398,7 @@ export function resetLLMClients() {
   _vertex = null;
   _vertexGlobal = null;
   _openai = null;
+  _bedrock = null;
 }
 
 // ============================================================================

--- a/features/llm/clients/llm.clients.ts
+++ b/features/llm/clients/llm.clients.ts
@@ -108,6 +108,27 @@ function loadBedrockFactory(): typeof createAmazonBedrock {
 
 const clientLogger = getAppLogger('features', 'LLM', 'clients');
 
+/**
+ * Bedrock 凭证缺失时的场景化提示。
+ *
+ * credential chain（IRSA/ECS instance role、AWS CLI profile）目前未接线
+ * （spec 明确 defer：`@aws-sdk/credential-providers` 为额外依赖），
+ * 检测到这些环境时给出针对性指引而不是泛泛的“未配置”。
+ */
+function bedrockCredentialHint(): string {
+  if (
+    process.env.AWS_WEB_IDENTITY_TOKEN_FILE ??
+    process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ??
+    process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+  ) {
+    return ' IAM role credentials detected (IRSA/ECS/EC2); credential chain support via @aws-sdk/credential-providers is intentionally not wired yet — use AI_BEDROCK_API_KEY or static SigV4 env keys for now.';
+  }
+  if (process.env.AWS_PROFILE) {
+    return ' AWS_PROFILE is set but the provider does not resolve CLI profiles; export static credentials (aws configure export-credentials --format env) or set AI_BEDROCK_API_KEY.';
+  }
+  return '';
+}
+
 // ============================================================================
 // OpenRouter 客户端
 // ============================================================================
@@ -345,7 +366,7 @@ function getBedrock() {
     const hasSigV4 = !!process.env.AWS_ACCESS_KEY_ID && !!process.env.AWS_SECRET_ACCESS_KEY;
     if (!apiKey && !hasBearerToken && !hasSigV4) {
       throw Oops.Panic.Config(
-        'AWS Bedrock credentials are not configured. Set AI_BEDROCK_API_KEY, AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY',
+        `AWS Bedrock credentials are not configured. Set AI_BEDROCK_API_KEY, AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY.${bedrockCredentialHint()}`,
       );
     }
     const region = SysEnv.AI_BEDROCK_REGION ?? process.env.AWS_REGION ?? 'us-east-1';

--- a/features/llm/clients/options.helpers.ts
+++ b/features/llm/clients/options.helpers.ts
@@ -4,13 +4,14 @@
  * 提供常用场景的便利函数，自动处理不同 Provider 的差异
  */
 
+import { bedrockThinkingOptions } from './bedrock.client';
 import { googleOptions } from './google.client';
 import { openrouterOptions } from './openrouter.client';
 
 /**
  * Provider 类型
  */
-export type ProviderType = 'openrouter' | 'google' | 'vertex' | 'vertex-global';
+export type ProviderType = 'openrouter' | 'google' | 'vertex' | 'vertex-global' | 'bedrock';
 
 /**
  * 根据 Provider 类型生成禁用 Thinking 的 options
@@ -32,7 +33,7 @@ export type ProviderType = 'openrouter' | 'google' | 'vertex' | 'vertex-global';
  * });
  * ```
  */
-export function disableThinkingOptions(provider: ProviderType) {
+export function disableThinkingOptions(provider: ProviderType, modelId?: string) {
   switch (provider) {
     case 'openrouter':
       return openrouterOptions({ disableThinking: true });
@@ -40,6 +41,9 @@ export function disableThinkingOptions(provider: ProviderType) {
     case 'vertex':
     case 'vertex-global':
       return googleOptions({ disableThinking: true });
+    case 'bedrock':
+      // Bedrock 需要 modelId 判断家族；缺 modelId 时不下发 disable（与裸 provider 调用兼容）
+      return modelId ? bedrockThinkingOptions(modelId, 'none') : {};
     default:
       return {};
   }
@@ -57,7 +61,7 @@ export function disableThinkingOptions(provider: ProviderType) {
  * });
  * ```
  */
-export function reasoningEffortOptions(provider: ProviderType, effort: 'low' | 'medium' | 'high') {
+export function reasoningEffortOptions(provider: ProviderType, effort: 'low' | 'medium' | 'high', modelId?: string) {
   switch (provider) {
     case 'openrouter':
       return openrouterOptions({ reasoningEffort: effort });
@@ -69,6 +73,9 @@ export function reasoningEffortOptions(provider: ProviderType, effort: 'low' | '
       const budgetMap = { low: 1024, medium: 4096, high: 8192 };
       return googleOptions({ thinkingBudget: budgetMap[effort] });
     }
+    case 'bedrock':
+      // anthropic → budgetTokens；nova 2 → maxReasoningEffort；其他家族内部 warn + 空
+      return modelId ? bedrockThinkingOptions(modelId, effort) : {};
     default:
       return {};
   }

--- a/features/llm/types/model.types.spec.ts
+++ b/features/llm/types/model.types.spec.ts
@@ -1,5 +1,7 @@
 import 'reflect-metadata';
 
+import { SysEnv } from '@app/env';
+
 import {
   getModel,
   getModelId,
@@ -258,5 +260,141 @@ describe('validateModelKey', () => {
     const result = validateModelKey('nonexistent:model');
     expect(result.valid).toBe(false);
     expect(result.error).toContain('not registered');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AWS Bedrock provider
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('bedrock model keys', () => {
+  it('M1: should parse and resolve a bedrock key to its registry modelId', () => {
+    const result = parseModelSpec('bedrock:claude-sonnet-4.5');
+    expect(result.provider).toBe('bedrock');
+    expect(result.bedrock).toBeUndefined();
+
+    const config = getModel('bedrock:claude-sonnet-4.5');
+    expect(config.provider).toBe('bedrock');
+    expect(config.modelId).toBe('us.anthropic.claude-sonnet-4-5-20250929-v1:0');
+  });
+
+  it('M1: should register the full initial bedrock model set', () => {
+    const expected: Partial<Record<LLMModelKey, string>> = {
+      'bedrock:claude-haiku-4.5': 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+      'bedrock:claude-sonnet-4.5': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      'bedrock:claude-sonnet-4.6': 'us.anthropic.claude-sonnet-4-6',
+      'bedrock:claude-opus-4.5': 'us.anthropic.claude-opus-4-5-20251101-v1:0',
+      'bedrock:claude-opus-4.6': 'us.anthropic.claude-opus-4-6-v1',
+      'bedrock:claude-opus-4.7': 'us.anthropic.claude-opus-4-7',
+      'bedrock:kimi-k2.5': 'moonshotai.kimi-k2.5',
+      'bedrock:kimi-k2-thinking': 'moonshot.kimi-k2-thinking',
+      'bedrock:deepseek-v3.2': 'deepseek.v3.2',
+      'bedrock:minimax-m2.5': 'minimax.minimax-m2.5',
+      'bedrock:nova-pro': 'us.amazon.nova-pro-v1:0',
+      'bedrock:nova-lite': 'us.amazon.nova-lite-v1:0',
+      'bedrock:nova-2-lite': 'us.amazon.nova-2-lite-v1:0',
+    };
+    for (const [key, modelId] of Object.entries(expected)) {
+      expect(isModelRegistered(key)).toBe(true);
+      expect(getModelId(key as LLMModelKey)).toBe(modelId);
+    }
+  });
+
+  it('M1: should mark kimi-k2-thinking and minimax-m2.5 as reasoningRequired', () => {
+    expect(getModel('bedrock:kimi-k2-thinking').reasoningRequired).toBe(true);
+    expect(getModel('bedrock:minimax-m2.5').reasoningRequired).toBe(true);
+  });
+
+  it('M2: should parse bedrock.serviceTier as provider-namespaced options', () => {
+    const spec = 'bedrock:claude-haiku-4.5?bedrock.serviceTier=flex' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.provider).toBe('bedrock');
+    expect(result.bedrock).toEqual({ serviceTier: 'flex' });
+    expect(result.vertex).toBeUndefined();
+    expect(result.openrouter).toBeUndefined();
+  });
+
+  it('M2: should parse all valid bedrock.serviceTier values', () => {
+    for (const tier of ['default', 'reserved', 'priority', 'flex'] as const) {
+      const result = parseModelSpec(`bedrock:claude-haiku-4.5?bedrock.serviceTier=${tier}` as LLMModelSpec);
+      expect(result.bedrock).toEqual({ serviceTier: tier });
+    }
+  });
+
+  it('M3: should ignore bedrock.serviceTier on non-bedrock providers with warning', () => {
+    const spec = 'openrouter:claude-sonnet-4.5?bedrock.serviceTier=flex' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.provider).toBe('openrouter');
+    expect(result.bedrock).toBeUndefined();
+  });
+
+  it('M4: should ignore invalid bedrock.serviceTier value with warning', () => {
+    const spec = 'bedrock:claude-haiku-4.5?bedrock.serviceTier=turbo' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.provider).toBe('bedrock');
+    expect(result.bedrock).toBeUndefined();
+  });
+
+  it('N2: should keep a bedrock fallback model in the chain', () => {
+    const spec = 'openrouter:gemini-3.5-flash?fallback=bedrock:claude-haiku-4.5' as LLMModelSpec;
+    const result = parseModelSpec(spec);
+    expect(result.fallbackModels).toEqual(['bedrock:claude-haiku-4.5']);
+  });
+
+  it('M13: validateModelKey should fail a bedrock key when no credentials are configured', () => {
+    const sysEnvMut = SysEnv as unknown as Record<string, string | undefined>;
+    const savedSysKey = sysEnvMut.AI_BEDROCK_API_KEY;
+    const savedBearer = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const savedAkid = process.env.AWS_ACCESS_KEY_ID;
+    const savedSecret = process.env.AWS_SECRET_ACCESS_KEY;
+    delete sysEnvMut.AI_BEDROCK_API_KEY;
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    try {
+      const result = validateModelKey('bedrock:claude-haiku-4.5');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('bedrock');
+      expect(result.error).toContain('AI_BEDROCK_API_KEY');
+    } finally {
+      if (savedSysKey !== undefined) sysEnvMut.AI_BEDROCK_API_KEY = savedSysKey;
+      if (savedBearer !== undefined) process.env.AWS_BEARER_TOKEN_BEDROCK = savedBearer;
+      if (savedAkid !== undefined) process.env.AWS_ACCESS_KEY_ID = savedAkid;
+      if (savedSecret !== undefined) process.env.AWS_SECRET_ACCESS_KEY = savedSecret;
+    }
+  });
+
+  it('M13: validateModelKey should pass a bedrock key when AI_BEDROCK_API_KEY is set', () => {
+    const sysEnvMut = SysEnv as unknown as Record<string, string | undefined>;
+    const savedSysKey = sysEnvMut.AI_BEDROCK_API_KEY;
+    sysEnvMut.AI_BEDROCK_API_KEY = 'test-bedrock-key';
+    try {
+      const result = validateModelKey('bedrock:claude-haiku-4.5');
+      expect(result.valid).toBe(true);
+    } finally {
+      if (savedSysKey === undefined) delete sysEnvMut.AI_BEDROCK_API_KEY;
+      else sysEnvMut.AI_BEDROCK_API_KEY = savedSysKey;
+    }
+  });
+
+  it('M13: validateModelKey should pass a bedrock key when SigV4 env credentials are set', () => {
+    const sysEnvMut = SysEnv as unknown as Record<string, string | undefined>;
+    const savedSysKey = sysEnvMut.AI_BEDROCK_API_KEY;
+    const savedAkid = process.env.AWS_ACCESS_KEY_ID;
+    const savedSecret = process.env.AWS_SECRET_ACCESS_KEY;
+    delete sysEnvMut.AI_BEDROCK_API_KEY;
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_ACCESS_KEY_ID = 'test-akid';
+    process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
+    try {
+      const result = validateModelKey('bedrock:claude-haiku-4.5');
+      expect(result.valid).toBe(true);
+    } finally {
+      if (savedSysKey !== undefined) sysEnvMut.AI_BEDROCK_API_KEY = savedSysKey;
+      if (savedAkid === undefined) delete process.env.AWS_ACCESS_KEY_ID;
+      else process.env.AWS_ACCESS_KEY_ID = savedAkid;
+      if (savedSecret === undefined) delete process.env.AWS_SECRET_ACCESS_KEY;
+      else process.env.AWS_SECRET_ACCESS_KEY = savedSecret;
+    }
   });
 });

--- a/features/llm/types/model.types.spec.ts
+++ b/features/llm/types/model.types.spec.ts
@@ -285,7 +285,6 @@ describe('bedrock model keys', () => {
       'bedrock:claude-sonnet-4.6': 'us.anthropic.claude-sonnet-4-6',
       'bedrock:claude-opus-4.5': 'us.anthropic.claude-opus-4-5-20251101-v1:0',
       'bedrock:claude-opus-4.6': 'us.anthropic.claude-opus-4-6-v1',
-      'bedrock:claude-opus-4.7': 'us.anthropic.claude-opus-4-7',
       'bedrock:kimi-k2.5': 'moonshotai.kimi-k2.5',
       'bedrock:kimi-k2-thinking': 'moonshot.kimi-k2-thinking',
       'bedrock:deepseek-v3.2': 'deepseek.v3.2',

--- a/features/llm/types/model.types.ts
+++ b/features/llm/types/model.types.ts
@@ -614,8 +614,6 @@ export interface LLMModelRegistry {
   'bedrock:claude-opus-4.5': ModelConfig<'bedrock'>;
   /** Claude Opus 4.6 */
   'bedrock:claude-opus-4.6': ModelConfig<'bedrock'>;
-  /** Claude Opus 4.7 */
-  'bedrock:claude-opus-4.7': ModelConfig<'bedrock'>;
   /** Kimi K2.5（on-demand，moonshotai.kimi-k2.5） */
   'bedrock:kimi-k2.5': ModelConfig<'bedrock'>;
   /** Kimi K2 Thinking（on-demand；reasoning 强制开启，无法关闭） */
@@ -1098,7 +1096,6 @@ const modelRegistry = new Map<string, ModelConfig>([
   ['bedrock:claude-sonnet-4.6', { provider: 'bedrock', modelId: 'us.anthropic.claude-sonnet-4-6' }],
   ['bedrock:claude-opus-4.5', { provider: 'bedrock', modelId: 'us.anthropic.claude-opus-4-5-20251101-v1:0' }],
   ['bedrock:claude-opus-4.6', { provider: 'bedrock', modelId: 'us.anthropic.claude-opus-4-6-v1' }],
-  ['bedrock:claude-opus-4.7', { provider: 'bedrock', modelId: 'us.anthropic.claude-opus-4-7' }],
   ['bedrock:kimi-k2.5', { provider: 'bedrock', modelId: 'moonshotai.kimi-k2.5' }],
   ['bedrock:kimi-k2-thinking', { provider: 'bedrock', modelId: 'moonshot.kimi-k2-thinking', reasoningRequired: true }],
   ['bedrock:deepseek-v3.2', { provider: 'bedrock', modelId: 'deepseek.v3.2' }],

--- a/features/llm/types/model.types.ts
+++ b/features/llm/types/model.types.ts
@@ -90,6 +90,21 @@ export interface VertexModelOptions {
 }
 
 /**
+ * AWS Bedrock service tier（per-request inference 服务层级）。
+ *
+ * 通过 `bedrock.serviceTier` model-spec 参数传递，映射到 Converse API 的 serviceTier。
+ * 各模型的可用层级以 AWS 官方文档为准。
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html
+ */
+export type BedrockServiceTier = 'default' | 'reserved' | 'priority' | 'flex';
+
+/** Bedrock-specific options parsed from model specs. */
+export interface BedrockModelOptions {
+  serviceTier?: BedrockServiceTier;
+}
+
+/**
  * Model 配置接口
  */
 export interface ModelConfig<P extends string = string> {
@@ -581,6 +596,40 @@ export interface LLMModelRegistry {
   'vertex-global:gemini-3.1-flash-lite': ModelConfig<'vertex-global'>;
   'vertex-global:gemini-3.5-flash': ModelConfig<'vertex-global'>;
   'vertex-global:gemini-3.1-pro-preview': ModelConfig<'vertex-global'>;
+
+  // ==================== AWS Bedrock ====================
+  // 模型可用性已在 mission-ai-v2（account 421454274824）/ us-east-2 验证（2026-07-17）。
+  // Claude 全系为 inference-profile only，modelId 使用 us.anthropic.* 前缀。
+  /**
+   * Claude Haiku 4.5 - 低价快速
+   *
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+   */
+  'bedrock:claude-haiku-4.5': ModelConfig<'bedrock'>;
+  /** Claude Sonnet 4.5 */
+  'bedrock:claude-sonnet-4.5': ModelConfig<'bedrock'>;
+  /** Claude Sonnet 4.6 */
+  'bedrock:claude-sonnet-4.6': ModelConfig<'bedrock'>;
+  /** Claude Opus 4.5 */
+  'bedrock:claude-opus-4.5': ModelConfig<'bedrock'>;
+  /** Claude Opus 4.6 */
+  'bedrock:claude-opus-4.6': ModelConfig<'bedrock'>;
+  /** Claude Opus 4.7 */
+  'bedrock:claude-opus-4.7': ModelConfig<'bedrock'>;
+  /** Kimi K2.5（on-demand，moonshotai.kimi-k2.5） */
+  'bedrock:kimi-k2.5': ModelConfig<'bedrock'>;
+  /** Kimi K2 Thinking（on-demand；reasoning 强制开启，无法关闭） */
+  'bedrock:kimi-k2-thinking': ModelConfig<'bedrock'>;
+  /** DeepSeek V3.2（on-demand） */
+  'bedrock:deepseek-v3.2': ModelConfig<'bedrock'>;
+  /** MiniMax M2.5（on-demand；reasoning 强制开启，无法关闭） */
+  'bedrock:minimax-m2.5': ModelConfig<'bedrock'>;
+  /** Amazon Nova Pro（inference profile） */
+  'bedrock:nova-pro': ModelConfig<'bedrock'>;
+  /** Amazon Nova Lite（inference profile / on-demand） */
+  'bedrock:nova-lite': ModelConfig<'bedrock'>;
+  /** Amazon Nova 2 Lite（inference profile；支持 maxReasoningEffort） */
+  'bedrock:nova-2-lite': ModelConfig<'bedrock'>;
 }
 
 /**
@@ -632,11 +681,14 @@ export interface ParsedModelSpec {
   vertex: VertexModelOptions | undefined;
   /** Provider-namespaced OpenRouter options. */
   openrouter: OpenRouterModelOptions | undefined;
+  /** Provider-namespaced Bedrock options. */
+  bedrock: BedrockModelOptions | undefined;
 }
 
 const VALID_THINKING_EFFORTS = new Set<string>(['none', 'low', 'medium', 'high']);
 const VALID_VERTEX_TIERS = new Set<string>(['standard', 'flex', 'priority']);
 const VALID_VERTEX_REQUEST_TYPES = new Set<string>(['shared']);
+const VALID_BEDROCK_SERVICE_TIERS = new Set<string>(['default', 'reserved', 'priority', 'flex']);
 const REMOVED_MODEL_SPEC_PARAMS = new Map([
   ['tier', 'vertex.tier'],
   ['vertexRequestType', 'vertex.requestType'],
@@ -676,6 +728,7 @@ export function parseModelSpec(spec: LLMModelSpec): ParsedModelSpec {
       fallbackModels: [],
       vertex: undefined,
       openrouter: undefined,
+      bedrock: undefined,
     };
   }
   const key = spec.slice(0, qIdx) as LLMModelKey;
@@ -774,6 +827,21 @@ export function parseModelSpec(spec: LLMModelSpec): ParsedModelSpec {
     }
   }
 
+  // bedrock.serviceTier → Bedrock service tier.
+  const serviceTierRaw = params.get('bedrock.serviceTier');
+  let serviceTier: BedrockServiceTier | undefined;
+  if (serviceTierRaw !== null) {
+    if (provider !== 'bedrock') {
+      logger.warning`[parseModelSpec] bedrock.serviceTier requested for non-bedrock provider=${provider} in "${spec}", ignoring`;
+    } else if (VALID_BEDROCK_SERVICE_TIERS.has(serviceTierRaw)) {
+      serviceTier = serviceTierRaw as BedrockServiceTier;
+    } else {
+      logger.warning`[parseModelSpec] Invalid bedrock.serviceTier "${serviceTierRaw}" in "${spec}", ignoring. Valid: ${[...VALID_BEDROCK_SERVICE_TIERS].join(', ')}`;
+    }
+  }
+
+  const bedrock = serviceTier !== undefined ? { serviceTier } : undefined;
+
   const vertex =
     tier !== undefined || vertexRequestType !== undefined
       ? {
@@ -782,7 +850,7 @@ export function parseModelSpec(spec: LLMModelSpec): ParsedModelSpec {
         }
       : undefined;
 
-  return { key, provider, thinking, maxRetries, timeout, fallbackModels, vertex, openrouter };
+  return { key, provider, thinking, maxRetries, timeout, fallbackModels, vertex, openrouter, bedrock };
 }
 
 /**
@@ -1020,6 +1088,24 @@ const modelRegistry = new Map<string, ModelConfig>([
       supportedTiers: ['standard', 'flex', 'priority'],
     },
   ],
+
+  // AWS Bedrock 模型
+  // 可用性已在 mission-ai-v2 (account 421454274824) / us-east-2 验证（2026-07-17）。
+  // Claude 全系为 inference-profile only，modelId 必须带 us. 前缀；
+  // 区域需为美国区域端点（us-east-1/us-east-2/us-west-2…），见 specs/2026-07-17-llm-bedrock-provider.tpdd.md。
+  ['bedrock:claude-haiku-4.5', { provider: 'bedrock', modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0' }],
+  ['bedrock:claude-sonnet-4.5', { provider: 'bedrock', modelId: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0' }],
+  ['bedrock:claude-sonnet-4.6', { provider: 'bedrock', modelId: 'us.anthropic.claude-sonnet-4-6' }],
+  ['bedrock:claude-opus-4.5', { provider: 'bedrock', modelId: 'us.anthropic.claude-opus-4-5-20251101-v1:0' }],
+  ['bedrock:claude-opus-4.6', { provider: 'bedrock', modelId: 'us.anthropic.claude-opus-4-6-v1' }],
+  ['bedrock:claude-opus-4.7', { provider: 'bedrock', modelId: 'us.anthropic.claude-opus-4-7' }],
+  ['bedrock:kimi-k2.5', { provider: 'bedrock', modelId: 'moonshotai.kimi-k2.5' }],
+  ['bedrock:kimi-k2-thinking', { provider: 'bedrock', modelId: 'moonshot.kimi-k2-thinking', reasoningRequired: true }],
+  ['bedrock:deepseek-v3.2', { provider: 'bedrock', modelId: 'deepseek.v3.2' }],
+  ['bedrock:minimax-m2.5', { provider: 'bedrock', modelId: 'minimax.minimax-m2.5', reasoningRequired: true }],
+  ['bedrock:nova-pro', { provider: 'bedrock', modelId: 'us.amazon.nova-pro-v1:0' }],
+  ['bedrock:nova-lite', { provider: 'bedrock', modelId: 'us.amazon.nova-lite-v1:0' }],
+  ['bedrock:nova-2-lite', { provider: 'bedrock', modelId: 'us.amazon.nova-2-lite-v1:0' }],
 ]);
 
 // ==================== 注册函数 ====================
@@ -1170,6 +1256,14 @@ const providerConfigRequirements: Partial<Record<string, ProviderConfigRequireme
   'vertex-global': {
     envVar: 'GOOGLE_VERTEX_PROJECT',
     configured: () => !!SysEnv.GOOGLE_VERTEX_PROJECT,
+  },
+  bedrock: {
+    // 认证优先级：AI_BEDROCK_API_KEY > AWS_BEARER_TOKEN_BEDROCK > SigV4 静态凭证（与 @ai-sdk/amazon-bedrock 一致）
+    envVar: 'AI_BEDROCK_API_KEY',
+    configured: () =>
+      !!SysEnv.AI_BEDROCK_API_KEY ||
+      !!process.env.AWS_BEARER_TOKEN_BEDROCK ||
+      (!!process.env.AWS_ACCESS_KEY_ID && !!process.env.AWS_SECRET_ACCESS_KEY),
   },
   openai: {
     envVar: 'AI_OPENAI_API_KEY',

--- a/features/llm/utils/cost-calculator.spec.ts
+++ b/features/llm/utils/cost-calculator.spec.ts
@@ -33,4 +33,28 @@ describe('getCostFromUsage bedrock', () => {
     const usage = { cost: 0.123, inputTokens: 1_000_000, outputTokens: 1_000_000 };
     expect(getCostFromUsage(usage, 'bedrock:claude-sonnet-4.5')).toBe(0.123);
   });
+
+  it('applies flex tier multiplier (50% of on-demand)', () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    // $3/$15 standard → flex: $1.5/$7.5
+    expect(getCostFromUsage(usage, 'bedrock:claude-sonnet-4.5', { bedrockServiceTier: 'flex' })).toBe(9);
+  });
+
+  it('applies priority tier multiplier (1.75x of on-demand)', () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    // $3/$15 standard → priority: $5.25/$26.25
+    expect(getCostFromUsage(usage, 'bedrock:claude-sonnet-4.5', { bedrockServiceTier: 'priority' })).toBe(31.5);
+  });
+
+  it('returns null for reserved tier (commitment-based, not per-token)', () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    expect(getCostFromUsage(usage, 'bedrock:claude-sonnet-4.5', { bedrockServiceTier: 'reserved' })).toBeNull();
+  });
+
+  it('default tier keeps standard pricing and non-bedrock providers ignore tier context', () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    expect(getCostFromUsage(usage, 'bedrock:claude-sonnet-4.5', { bedrockServiceTier: 'default' })).toBe(18);
+    // openrouter key 不受 bedrockServiceTier 影响（google/gemini-3.5-flash: $1.5/$9）
+    expect(getCostFromUsage(usage, 'openrouter:gemini-3.5-flash', { bedrockServiceTier: 'flex' })).toBeCloseTo(10.5);
+  });
 });

--- a/features/llm/utils/cost-calculator.spec.ts
+++ b/features/llm/utils/cost-calculator.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Bedrock 成本计算测试（spec N3）
+ *
+ * bedrock key 通过 registry modelId 解析定价，不做字符串推导；
+ * 未注册/未定价的模型返回 null。
+ */
+
+import { getCostFromUsage } from './cost-calculator';
+
+import { describe, expect, it } from 'bun:test';
+
+describe('getCostFromUsage bedrock', () => {
+  it('resolves pricing for bedrock keys via the registry modelId', () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    // us.anthropic.claude-sonnet-4-5-20250929-v1:0: $3/$15 per 1M
+    expect(getCostFromUsage(usage, 'bedrock:claude-sonnet-4.5')).toBe(18);
+  });
+
+  it('resolves pricing for on-demand bedrock models', () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    // moonshotai.kimi-k2.5: $0.6/$3 per 1M
+    expect(getCostFromUsage(usage, 'bedrock:kimi-k2.5')).toBeCloseTo(3.6);
+    // deepseek.v3.2: $0.62/$1.85 per 1M
+    expect(getCostFromUsage(usage, 'bedrock:deepseek-v3.2')).toBeCloseTo(2.47);
+  });
+
+  it('returns null for unregistered bedrock keys instead of throwing', () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    expect(getCostFromUsage(usage, 'bedrock:no-such-model')).toBeNull();
+  });
+
+  it('prefers API-returned cost over manual calculation', () => {
+    const usage = { cost: 0.123, inputTokens: 1_000_000, outputTokens: 1_000_000 };
+    expect(getCostFromUsage(usage, 'bedrock:claude-sonnet-4.5')).toBe(0.123);
+  });
+});

--- a/features/llm/utils/cost-calculator.ts
+++ b/features/llm/utils/cost-calculator.ts
@@ -8,6 +8,8 @@
  * 价格数据来源：llm.clients.ts（2026-01）
  */
 
+import { getModel, isModelRegistered } from '../types/model.types';
+
 import type { LLMModelKey } from '../types/model.types';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -102,6 +104,23 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'openai/gpt-5.4-mini': { input: 0.75, output: 4.5 },
   'openai/gpt-5.4-nano': { input: 0.2, output: 1.25 },
   'openai/gpt-5.5': { input: 5.0, output: 30.0 },
+
+  // ==================== AWS Bedrock（key 为 registry 中的 Bedrock modelId）====================
+  // 定价来源：AWS Bedrock pricing（经 models.dev 镜像核对，2026-07-17）
+  // Claude us.* inference profile 与区域价格一致
+  'us.anthropic.claude-haiku-4-5-20251001-v1:0': { input: 1.0, output: 5.0 },
+  'us.anthropic.claude-sonnet-4-5-20250929-v1:0': { input: 3.0, output: 15.0 },
+  'us.anthropic.claude-sonnet-4-6': { input: 3.0, output: 15.0 },
+  'us.anthropic.claude-opus-4-5-20251101-v1:0': { input: 5.0, output: 25.0 },
+  'us.anthropic.claude-opus-4-6-v1': { input: 5.0, output: 25.0 },
+  'us.anthropic.claude-opus-4-7': { input: 5.0, output: 25.0 },
+  'moonshotai.kimi-k2.5': { input: 0.6, output: 3.0 },
+  'moonshot.kimi-k2-thinking': { input: 0.6, output: 2.5 },
+  'deepseek.v3.2': { input: 0.62, output: 1.85 },
+  'minimax.minimax-m2.5': { input: 0.3, output: 1.2 },
+  'us.amazon.nova-pro-v1:0': { input: 0.8, output: 3.2 },
+  'us.amazon.nova-lite-v1:0': { input: 0.06, output: 0.24 },
+  'us.amazon.nova-2-lite-v1:0': { input: 0.33, output: 2.75 },
 };
 
 /**
@@ -176,6 +195,11 @@ function calculateCostFromKey(
     } else if (provider === 'google') {
       // Google 直连格式是 'gemini-xxx'
       modelId = modelName;
+    } else if (provider === 'bedrock') {
+      // Bedrock key 的 modelId 无法从 key 字符串推导（如 bedrock:claude-sonnet-4.5 →
+      // us.anthropic.claude-sonnet-4-5-20250929-v1:0），必须查 registry
+      if (!isModelRegistered(modelKey)) return null;
+      modelId = getModel(modelKey).modelId;
     } else {
       return null;
     }

--- a/features/llm/utils/cost-calculator.ts
+++ b/features/llm/utils/cost-calculator.ts
@@ -10,7 +10,27 @@
 
 import { getModel, isModelRegistered } from '../types/model.types';
 
-import type { LLMModelKey } from '../types/model.types';
+import type { BedrockServiceTier, LLMModelKey } from '../types/model.types';
+
+/**
+ * Bedrock service tier 价格系数（相对 standard on-demand）。
+ *
+ * 来源：AWS Bedrock pricing — Flex 为 on-demand 的 50%，Priority 为 +75%（1.75x）。
+ * `reserved` 为承诺吞吐（非按 token 计费），不在此表，按 token 估算会误导，返回 null。
+ *
+ * @see https://aws.amazon.com/bedrock/pricing/
+ */
+const BEDROCK_SERVICE_TIER_MULTIPLIER: Record<Exclude<BedrockServiceTier, 'reserved'>, number> = {
+  default: 1,
+  flex: 0.5,
+  priority: 1.75,
+};
+
+/** getCostFromUsage 的可选上下文 */
+export interface CostContext {
+  /** Bedrock service tier（来自 model spec 的 `bedrock.serviceTier` 参数） */
+  bedrockServiceTier?: BedrockServiceTier;
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 价格表（每百万 tokens）
@@ -139,14 +159,14 @@ function getPricing(modelId: string): ModelPricing | null {
 /**
  * 计算 LLM 调用成本（内部使用）
  */
-function calculateCost(modelId: string, promptTokens: number, completionTokens: number): number | null {
+function calculateCost(modelId: string, promptTokens: number, completionTokens: number, multiplier = 1): number | null {
   const pricing = getPricing(modelId);
   if (!pricing) return null;
 
   const inputCost = (promptTokens / 1_000_000) * pricing.input;
   const outputCost = (completionTokens / 1_000_000) * pricing.output;
 
-  return inputCost + outputCost;
+  return (inputCost + outputCost) * multiplier;
 }
 
 /**
@@ -156,6 +176,7 @@ function calculateCostFromKey(
   modelKey: LLMModelKey | string,
   promptTokens: number,
   completionTokens: number,
+  context?: CostContext,
 ): number | null {
   // 如果包含 ':'，说明是 LLMModelKey 格式
   if (modelKey.includes(':')) {
@@ -165,6 +186,7 @@ function calculateCostFromKey(
     const modelName = modelParts.join(':');
 
     let modelId: string;
+    let multiplier = 1;
     if (provider === 'openrouter') {
       // 全称格式（含 '/'）：'z-ai/glm-5' 已是完整 modelId，直接使用
       if (modelName.includes('/')) {
@@ -199,11 +221,14 @@ function calculateCostFromKey(
       // us.anthropic.claude-sonnet-4-5-20250929-v1:0），必须查 registry
       if (!isModelRegistered(modelKey)) return null;
       modelId = getModel(modelKey).modelId;
+      // reserved 为承诺吞吐（非按 token 计费），按标准价估算会误导，返回 null
+      if (context?.bedrockServiceTier === 'reserved') return null;
+      multiplier = BEDROCK_SERVICE_TIER_MULTIPLIER[context?.bedrockServiceTier ?? 'default'];
     } else {
       return null;
     }
 
-    return calculateCost(modelId, promptTokens, completionTokens);
+    return calculateCost(modelId, promptTokens, completionTokens, multiplier);
   }
 
   // 否则当作 modelId 直接使用
@@ -219,7 +244,11 @@ function calculateCostFromKey(
  * @param modelKey - LLMModelKey（fallback 计算用）
  * @returns 成本（美元），如果无法计算返回 null
  */
-export function getCostFromUsage(usage: unknown, modelKey?: LLMModelKey | string): number | null {
+export function getCostFromUsage(
+  usage: unknown,
+  modelKey?: LLMModelKey | string,
+  context?: CostContext,
+): number | null {
   if (!usage || typeof usage !== 'object') return null;
   const usageObj = usage as Record<string, unknown>;
 
@@ -242,7 +271,7 @@ export function getCostFromUsage(usage: unknown, modelKey?: LLMModelKey | string
         : typeof usageObj.completionTokens === 'number'
           ? usageObj.completionTokens
           : 0;
-    return calculateCostFromKey(modelKey, inputTokens, outputTokens);
+    return calculateCostFromKey(modelKey, inputTokens, outputTokens, context);
   }
 
   return null;

--- a/features/llm/utils/cost-calculator.ts
+++ b/features/llm/utils/cost-calculator.ts
@@ -113,7 +113,6 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'us.anthropic.claude-sonnet-4-6': { input: 3.0, output: 15.0 },
   'us.anthropic.claude-opus-4-5-20251101-v1:0': { input: 5.0, output: 25.0 },
   'us.anthropic.claude-opus-4-6-v1': { input: 5.0, output: 25.0 },
-  'us.anthropic.claude-opus-4-7': { input: 5.0, output: 25.0 },
   'moonshotai.kimi-k2.5': { input: 0.6, output: 3.0 },
   'moonshot.kimi-k2-thinking': { input: 0.6, output: 2.5 },
   'deepseek.v3.2': { input: 0.62, output: 1.85 },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "radash": "^12.1.1"
   },
   "peerDependencies": {
+    "@ai-sdk/amazon-bedrock": "^5.0.0",
     "@ai-sdk/google": "^4.0.3",
     "@ai-sdk/google-vertex": "^5.0.4",
     "@ai-sdk/openai": "^4.0.4",
@@ -78,6 +79,9 @@
     "zod": "^4.3.6"
   },
   "peerDependenciesMeta": {
+    "@ai-sdk/amazon-bedrock": {
+      "optional": true
+    },
     "@ai-sdk/google": {
       "optional": true
     },
@@ -185,6 +189,7 @@
     }
   },
   "devDependencies": {
+    "@ai-sdk/amazon-bedrock": "^5.0.23",
     "@ai-sdk/google": "^4.0.14",
     "@ai-sdk/google-vertex": "^5.0.18",
     "@ai-sdk/openai": "^4.0.13",


### PR DESCRIPTION
## Summary

Adds `bedrock` as a first-class provider in LLM Model Keys, so any `LLMModelSpec` surface (env config, `LLM.generate*`, `model()`, fallback chains) can route to AWS Bedrock through the same registry/parser/auto-router pipeline as the existing four providers.

Spec (local): `specs/2026-07-17-llm-bedrock-provider.tpdd.md`

### What's included

- **Dependency**: `@ai-sdk/amazon-bedrock` as optional peer (`^5.0.0`); same provider-spec generation as the repo's ai@7 stack (`@ai-sdk/provider@4.0.3` / `provider-utils@5.0.10`)
- **13 registered keys**, all verified `AVAILABLE` + `AUTHORIZED` on the target AWS account / `us-east-2`:
  - Claude Haiku 4.5 / Sonnet 4.5 / Sonnet 4.6 / Opus 4.5 / Opus 4.6 / Opus 4.7 (via `us.anthropic.*` inference profiles — current-gen Claude is profile-only)
  - Kimi K2.5, Kimi K2 Thinking (`reasoningRequired`), DeepSeek V3.2, MiniMax M2.5 (`reasoningRequired`), Nova Pro, Nova Lite, Nova 2 Lite
- **Auth** (mirrors the provider's own precedence): `AI_BEDROCK_API_KEY` → `AWS_BEARER_TOKEN_BEDROCK` → SigV4 `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`; `AI_BEDROCK_REGION` (default `us-east-1`); fail-fast `Oops.Panic.Config` naming all three paths
- **Spec param** `?bedrock.serviceTier=default|reserved|priority|flex` (warn + ignore on wrong provider / invalid value, same policy as `vertex.tier`)
- **Reasoning mapping by model family** (Converse rejects unknown fields): anthropic → `reasoningConfig.budgetTokens` (1024/4096/8192), Nova 2 → `maxReasoningEffort`, other families → warn + not sent; `reasoningRequired` models never receive disable options
- **Cost calculator**: `bedrock` branch resolves pricing via the registry `modelId` (no string munging); pricing sourced from AWS Bedrock pricing (models.dev mirror, 2026-07-17)
- Client init logs auth mode + region once, no secrets

### Test plan

- **595 pass / 0 fail** (`bun test`), `tsc --noEmit`, `eslint`, `check:dep-identity` all green
- +37 new tests: parser (M1–M4/M13/N2), options helpers (M7–M10), captured-fetch integration (routing, fail-fast auth, SigV4 signing, `serviceTier: {type}` + `additionalModelRequestFields.thinking.budget_tokens` payload positions, prepareStep, ApiFetcher plumbing), cost calc
- **Live smoke** (`bedrock.live.spec.ts`) is opt-in via `LLM_LIVE_TEST=1` — skipped in CI. Verified locally against the real account: `hello bedrock`, 14/6 tokens, ~1.9s

### Notes for reviewers

- Deviation from spec: registered `bedrock:nova-2-lite` (not in the original 12) because only Nova 2 supports `maxReasoningEffort` — Nova 1 (pro/lite) has no `reasoningConfig` support; spec updated accordingly
- OpenRouter `bedrock` routing profile (`openrouter.routing=bedrock`) is untouched and orthogonal
- Pre-existing gap (not fixed here, per spec): cost calculator still returns `null` for `vertex*` keys
- Deferred: `bedrock-anthropic` native provider, `credentialProvider` chain (SSO/IRSA), guardrails/cache points, embeddings/rerank/image, `global.*` profile keys
